### PR TITLE
Fix embed phase re-embedding jobs 3-4x per sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,12 +150,19 @@ up front by `validate_sync_config()` before any I/O. The orchestrator
 All phases update `PhaseState` objects directly for display. The fetch phase
 uses the same pattern as enrich/strip/embed — no event queue.
 
-Each phase (enrich, strip, embed) extends the `WorkerPhase` ABC (`sync/base.py`),
+`EnrichPhase` and `StripPhase` extend the `WorkerPhase` ABC (`sync/base.py`),
 which provides: DB polling for work items, `ThreadPoolExecutor` parallelism,
-per-thread DB connections, graceful shutdown via `threading.Event`, and display
-state updates. Phases poll the database for unprocessed items, process them in
-worker threads, and write results back. This decouples phases — each can run
-independently via phase selection (`jsb sync strip`, `jsb sync embed`).
+per-thread DB connections via a single-threaded `WriteQueue`, graceful shutdown
+via `threading.Event`, and display state updates. Phases poll the database
+for unprocessed items, process them in worker threads, and write results back.
+This decouples phases — each can run independently via phase selection
+(`jsb sync strip`, `jsb sync embed`).
+
+`EmbedPhase` does NOT extend `WorkerPhase`. It runs a synchronous, single-threaded
+poll → embed → write loop. `embed_texts()` saturates the TPM quota from one
+worker via header-based pacing, so the parallel machinery wasn't helping —
+and its prefetch-ahead dedup set (keyed on batch tuples) was the source of a
+race that re-embedded each job 3–4× per sync. See `sync/embed.py` for details.
 
 **Rate limiting:** Embedding pacing uses `x-ratelimit-remaining-tokens` response
 headers. If your provider returns these headers, pacing activates automatically.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,17 +91,27 @@ serialization natively via psycopg.
 
 ### DB-as-Queue Pattern
 
-Phases 2-4 extend the `WorkerPhase` ABC (`sync/base.py`). Each phase polls the
-database for unprocessed work items, processes them in a `ThreadPoolExecutor`,
-and writes results back. This decouples phases from each other — the database
-is the coordination mechanism, not in-memory queues or callbacks.
+`EnrichPhase` and `StripPhase` extend the `WorkerPhase` ABC (`sync/base.py`).
+Each polls the database for unprocessed work items, processes them in a
+`ThreadPoolExecutor`, and writes results back through a single-threaded
+`WriteQueue`. The database is the coordination mechanism — no in-memory
+queues between phases.
 
 `WorkerPhase` provides:
 - `count_remaining()` / `poll_work(batch_size)` / `process_item(item)` — abstract methods subclasses implement
 - `ThreadPoolExecutor` with configurable `max_workers`
-- Per-thread DB connections via `threading.local()` and `_get_thread_store()`
+- Single-threaded `WriteQueue` for all DB writes
 - Graceful shutdown via `threading.Event`
 - `PhaseState` display updates on advance/error
+
+**`EmbedPhase` is the exception.** It does *not* extend `WorkerPhase`; it
+runs a plain synchronous poll → embed → write loop on a single thread.
+`embed_texts()` (in `embeddings.py`) paces itself with the provider's
+`x-ratelimit-remaining-tokens` header, which saturates the TPM quota from
+one worker, so the parallel machinery wasn't buying anything — and its
+prefetch-ahead dedup set (keyed on batch tuples) was the source of a race
+that re-embedded each job several times per sync. See the docstring in
+`sync/embed.py` for details.
 
 ### Display
 

--- a/src/jobbuddy/sync/embed.py
+++ b/src/jobbuddy/sync/embed.py
@@ -4,19 +4,33 @@ Embed is intentionally single-threaded. `embed_texts()` paces itself with
 the `x-ratelimit-remaining-tokens` header (see embeddings.py), which is
 enough to saturate the provider TPM quota from one worker. Running wider
 was the source of a prefetch/dedupe race that re-embedded jobs several
-times per run: the producer loop would re-poll while a worker was mid-API
-call, build a batch with a different tuple shape, and the in-memory
-dedupe set keyed on that tuple wouldn't catch the overlap.
+times per run.
 
-The fix is to not prefetch at all. This phase runs a plain synchronous
-loop — poll, embed, write, repeat — so a job is eligible for exactly as
-long as it takes for its write to commit. No work queue, no thread pool,
-no dispatched set, no over-fetch trick.
+Mechanism of the old bug (for the next person tempted to re-parallelize):
+
+  1. `JobStore.list_jobs_needing_embeddings()` has no `ORDER BY`. Under
+     `LIMIT N`, Postgres is free to return any N matching rows in any
+     order, and does.
+  2. `WorkerPhase.run()` over-fetched (`poll_limit = batch_size + len(dispatched)`)
+     so polls taken while a worker was mid-API-call returned a DIFFERENT
+     row set than the batch currently in flight.
+  3. The in-memory dedupe set was keyed on the whole-batch tuple
+     `tuple(job_ids)`. Different row set → different tuple → not in
+     dispatched → re-queued. Every overlapping job got embedded a second
+     time (or third, or fourth).
+
+Tuple-keyed dedup was doomed the moment the underlying query was
+unordered. This phase runs a plain synchronous loop — poll, embed, write,
+repeat — so committed rows leave the `WHERE` clause before the next poll
+and the whole race class stops existing.
 
 Trade-off: no intra-phase parallelism. Re-introduce a dispatcher only if
 you switch to a provider that can't hit its TPM budget from a single
-worker, and be careful to key dedup on individual job ids, not batch
-tuples (that's what broke before).
+worker, and:
+  - Key dedup on individual job ids, not batch tuples
+  - Add `ORDER BY j.id` to `list_jobs_needing_embeddings` for determinism
+  - Don't trust the in-memory dedup set alone — let the DB query be the
+    source of truth about what still needs work
 """
 
 from __future__ import annotations
@@ -158,22 +172,7 @@ class EmbedPhase:
 
                 self.display.active_workers = 1
                 try:
-                    self._process_batch(batch)
-                except Exception as e:
-                    self.display.record_error()
-                    log.warning(
-                        "Embed batch failed (%d jobs): %s: %s",
-                        len(batch), type(e).__name__, e,
-                    )
-                    for job in batch:
-                        failures[job["id"]] += 1
-                        if failures[job["id"]] >= self.MAX_RETRIES:
-                            log.error(
-                                "Giving up on embed for %s/%s after %d failures",
-                                job["company_slug"], job["job_id"],
-                                failures[job["id"]],
-                            )
-                            skipped.add(job["id"])
+                    self._process_and_isolate(batch, failures, skipped)
                 finally:
                     self.display.active_workers = 0
 
@@ -199,6 +198,51 @@ class EmbedPhase:
     # -----------------------------------------------------------------
     # Batch processing
     # -----------------------------------------------------------------
+
+    def _process_and_isolate(
+        self,
+        batch: EmbedBatch,
+        failures: dict[int, int],
+        skipped: set[int],
+    ) -> None:
+        """Process a batch, bisecting on failure to isolate poison pills.
+
+        Only size-1 leaves charge `failures[]`. When a multi-item batch
+        fails, we split it in half and recurse — healthy jobs get embedded
+        in the half that doesn't contain the bad record, and only the
+        actual culprit accumulates retry count toward MAX_RETRIES.
+
+        Under a fully-transient failure (network down, provider outage),
+        every leaf fails and every job gets charged once per outer poll
+        iteration, which is the same behavior as a flat batch-level
+        failure would give. Worst case: ~2N API calls for an N-item
+        batch where every job is bad.
+        """
+        try:
+            self._process_batch(batch)
+            return
+        except Exception as e:
+            self.display.record_error()
+            log.warning(
+                "Embed batch failed (%d jobs): %s: %s",
+                len(batch), type(e).__name__, e,
+            )
+
+        if len(batch) == 1:
+            job = batch[0]
+            jid = job["id"]
+            failures[jid] += 1
+            if failures[jid] >= self.MAX_RETRIES:
+                log.error(
+                    "Giving up on embed for %s/%s after %d failures",
+                    job["company_slug"], job["job_id"], failures[jid],
+                )
+                skipped.add(jid)
+            return
+
+        mid = len(batch) // 2
+        self._process_and_isolate(batch[:mid], failures, skipped)
+        self._process_and_isolate(batch[mid:], failures, skipped)
 
     def _process_batch(self, batch: EmbedBatch) -> None:
         """Embed one batch and write results synchronously.

--- a/src/jobbuddy/sync/embed.py
+++ b/src/jobbuddy/sync/embed.py
@@ -1,93 +1,237 @@
-"""EmbedPhase -- embedding generation via OpenAI text-embedding-3-small.
+"""EmbedPhase -- single-threaded embedding generation.
 
-Single model. Batch processing to maximize throughput within API limits.
+Embed is intentionally single-threaded. `embed_texts()` paces itself with
+the `x-ratelimit-remaining-tokens` header (see embeddings.py), which is
+enough to saturate the provider TPM quota from one worker. Running wider
+was the source of a prefetch/dedupe race that re-embedded jobs several
+times per run: the producer loop would re-poll while a worker was mid-API
+call, build a batch with a different tuple shape, and the in-memory
+dedupe set keyed on that tuple wouldn't catch the overlap.
+
+The fix is to not prefetch at all. This phase runs a plain synchronous
+loop — poll, embed, write, repeat — so a job is eligible for exactly as
+long as it takes for its write to commit. No work queue, no thread pool,
+no dispatched set, no over-fetch trick.
+
+Trade-off: no intra-phase parallelism. Re-introduce a dispatcher only if
+you switch to a provider that can't hit its TPM budget from a single
+worker, and be careful to key dedup on individual job ids, not batch
+tuples (that's what broke before).
 """
 
 from __future__ import annotations
 
 import logging
 import threading
+from collections import defaultdict
+from typing import ClassVar
 
 from jobbuddy.embeddings import compute_batch_size, embed_texts
 from jobbuddy.models import Job
-from jobbuddy.sync.base import WorkerPhase
+from jobbuddy.store import JobStore
 from jobbuddy.sync.display import PhaseState
-from jobbuddy.types import EmbedBatch
+from jobbuddy.types import EmbedBatch, EmbedWorkItem
 
 log = logging.getLogger(__name__)
 
 
-class EmbedPhase(WorkerPhase["EmbedBatch"]):
+class EmbedPhase:
     """Generate embeddings for jobs with stripped descriptions.
 
-    Work unit = a batch of jobs (list of EmbedWorkItems from store).
-    Each batch is embedded in a single API call, then results are stored individually.
+    Single-threaded by design. See module docstring.
     """
 
-    def __init__(self, conninfo: str, *, display: PhaseState,
-                 max_workers: int = 1, slugs: list[str] | None = None,
-                 upstream_done: threading.Event | None = None):
-        super().__init__(conninfo, max_workers=max_workers, display=display,
-                         upstream_done=upstream_done)
-        self._batch_size = compute_batch_size()
+    # Rough accounting for per-call batching within embed_texts.
+    MAX_BATCH_TOKENS: ClassVar[int] = 50_000
+    CHARS_PER_TOKEN: ClassVar[int] = 4
+
+    # A job that fails this many times in a row is skipped so the phase
+    # can finish rather than looping forever on a poisoned record.
+    MAX_RETRIES: ClassVar[int] = 3
+
+    # Sleep between empty polls while waiting on upstream producers.
+    EMPTY_POLL_WAIT: ClassVar[float] = 1.0
+
+    def __init__(
+        self,
+        conninfo: str,
+        *,
+        display: PhaseState,
+        slugs: list[str] | None = None,
+        upstream_done: threading.Event | None = None,
+    ):
+        self.conninfo = conninfo
+        self.display = display
         self._slugs = slugs
+        self._upstream_done = upstream_done
+        self._shutdown = threading.Event()
+        self._store: JobStore | None = None
+        self._batch_size = compute_batch_size()
 
     @property
-    def batch_size(self) -> int:
-        """Override: use embedding-optimal batch size, not worker * 2."""
-        return self._batch_size
+    def max_workers(self) -> int:
+        """Always 1. Exposed so PhaseState/display code can treat this
+        phase the same as the parallel ones."""
+        return 1
 
-    def item_key(self, item: EmbedBatch) -> tuple:
-        return tuple(j["id"] for j in item)
+    def shutdown(self) -> None:
+        self._shutdown.set()
 
-    def item_label(self, item: EmbedBatch) -> str:
-        slugs = {j["company_slug"] for j in item}
-        return f"batch of {len(item)} jobs ({', '.join(sorted(slugs))})"
+    # -----------------------------------------------------------------
+    # Internal helpers
+    # -----------------------------------------------------------------
 
-    def count_remaining(self) -> int:
-        return self._get_reader().count_jobs_needing_embeddings(slugs=self._slugs)
+    def _get_store(self) -> JobStore:
+        if self._store is None:
+            self._store = JobStore(self.conninfo)
+        return self._store
 
-    def poll_work(self, batch_size: int) -> list[EmbedBatch]:
-        """Return a single batch of jobs as a one-element list (one work unit)."""
-        jobs = self._get_reader().list_jobs_needing_embeddings(slugs=self._slugs, limit=batch_size)
-        if not jobs:
-            return []
-        return [jobs]
+    def _count_remaining(self) -> int:
+        return self._get_store().count_jobs_needing_embeddings(slugs=self._slugs)
 
-    # Target ~50K tokens per batch for predictable pacing.
-    # ~4 chars per token is a rough estimate.
-    MAX_BATCH_TOKENS = 50_000
-    CHARS_PER_TOKEN = 4
+    def _poll(self, skipped: set[int]) -> list[EmbedWorkItem]:
+        """Fetch one batch of work, dropping jobs that hit MAX_RETRIES."""
+        # Over-fetch by the skip-set size so we can still fill a batch after
+        # filtering out permanently-failing items client-side.
+        limit = self._batch_size + len(skipped)
+        rows = self._get_store().list_jobs_needing_embeddings(
+            slugs=self._slugs, limit=limit,
+        )
+        return [r for r in rows if r["id"] not in skipped][: self._batch_size]
 
-    def process_item(self, item: EmbedBatch) -> None:
-        """Embed a batch of jobs and store results."""
-        jobs = item
-        texts = []
-        valid_jobs = []
+    def _wait_for_initial_work(self) -> int:
+        """Block until upstream produces work or signals done. Returns remaining count."""
+        assert self._upstream_done is not None
+        while not self._shutdown.is_set():
+            self._shutdown.wait(timeout=self.EMPTY_POLL_WAIT)
+            total = self._count_remaining()
+            if total > 0:
+                return total
+            if self._upstream_done.is_set():
+                return self._count_remaining()
+        return 0
+
+    # -----------------------------------------------------------------
+    # Main loop
+    # -----------------------------------------------------------------
+
+    def run(self) -> None:
+        total = self._count_remaining()
+
+        if total == 0 and (
+            self._upstream_done is None or self._upstream_done.is_set()
+        ):
+            log.info("%s phase skipped (nothing to do)", self.display.name)
+            if self._store is not None:
+                self._store.close()
+                self._store = None
+            return
+
+        if total == 0 and self._upstream_done is not None:
+            total = self._wait_for_initial_work()
+            if total == 0:
+                log.info("%s phase skipped (nothing to do)", self.display.name)
+                if self._store is not None:
+                    self._store.close()
+                    self._store = None
+                return
+
+        log.info("%s phase starting (%d items)", self.display.name, total)
+        self.display.start(total)
+        self.display.max_workers = self.max_workers
+
+        failures: dict[int, int] = defaultdict(int)
+        skipped: set[int] = set()
+
+        try:
+            while not self._shutdown.is_set():
+                batch = self._poll(skipped)
+
+                if not batch:
+                    if (
+                        self._upstream_done is not None
+                        and not self._upstream_done.is_set()
+                    ):
+                        self._shutdown.wait(timeout=self.EMPTY_POLL_WAIT)
+                        continue
+                    break
+
+                self.display.active_workers = 1
+                try:
+                    self._process_batch(batch)
+                except Exception as e:
+                    self.display.record_error()
+                    log.warning(
+                        "Embed batch failed (%d jobs): %s: %s",
+                        len(batch), type(e).__name__, e,
+                    )
+                    for job in batch:
+                        failures[job["id"]] += 1
+                        if failures[job["id"]] >= self.MAX_RETRIES:
+                            log.error(
+                                "Giving up on embed for %s/%s after %d failures",
+                                job["company_slug"], job["job_id"],
+                                failures[job["id"]],
+                            )
+                            skipped.add(job["id"])
+                finally:
+                    self.display.active_workers = 0
+
+                # Keep the total display honest while upstream is still
+                # producing new work.
+                if self._upstream_done is not None:
+                    new_total = self._count_remaining() + self.display.done
+                    if (
+                        self.display.total is not None
+                        and new_total > self.display.total
+                    ):
+                        self.display.total = new_total
+        finally:
+            if self._store is not None:
+                self._store.close()
+                self._store = None
+            self.display.finish()
+            log.info(
+                "%s phase done (%d done, %d errors)",
+                self.display.name, self.display.done, self.display.errors,
+            )
+
+    # -----------------------------------------------------------------
+    # Batch processing
+    # -----------------------------------------------------------------
+
+    def _process_batch(self, batch: EmbedBatch) -> None:
+        """Embed one batch and write results synchronously.
+
+        Raises on any failure so run() can record an error and drive retry.
+        """
+        texts: list[str] = []
+        valid: list[EmbedWorkItem] = []
         est_tokens = 0
-        for j in jobs:
+
+        for j in batch:
             job = Job(
                 id=j["job_id"], title=j["title"],
                 location=j["location"] or "", url="", apply_url="",
                 department=j["department"],
             )
-            text = job.embed_text(j["company_slug"], description_stripped=j["description_stripped"])
-            if text:
-                text_tokens = len(text) // self.CHARS_PER_TOKEN
-                if est_tokens + text_tokens > self.MAX_BATCH_TOKENS and texts:
-                    break
-                texts.append(text)
-                valid_jobs.append(j)
-                est_tokens += text_tokens
+            text = job.embed_text(
+                j["company_slug"],
+                description_stripped=j["description_stripped"],
+            )
+            if not text:
+                continue
+            text_tokens = len(text) // self.CHARS_PER_TOKEN
+            if est_tokens + text_tokens > self.MAX_BATCH_TOKENS and texts:
+                break
+            texts.append(text)
+            valid.append(j)
+            est_tokens += text_tokens
 
         if not texts:
             return
 
-        try:
-            vectors, total_tokens = embed_texts(texts)
-        except Exception as e:
-            log.warning("Embedding batch failed (%d jobs): %s", len(valid_jobs), e)
-            raise
+        vectors, total_tokens = embed_texts(texts)
 
         if total_tokens:
             self.display.add_to_info_counter(total_tokens)
@@ -95,12 +239,12 @@ class EmbedPhase(WorkerPhase["EmbedBatch"]):
 
         embed_items = [
             (j["id"], str(j["job_hash"]), str(j["company_hash"]), vec)
-            for j, vec in zip(valid_jobs, vectors)
+            for j, vec in zip(valid, vectors)
         ]
-        self.submit_write(
-            lambda store, items=embed_items: store.store_embeddings(items)
-        )
-        for job_info in valid_jobs:
+        # Synchronous write — no WriteQueue needed since we're single-threaded.
+        self._get_store().store_embeddings(embed_items)
+
+        for job_info in valid:
             self.display.advance(
                 detail=f"{job_info['company_slug']}: {job_info['title']}"
             )

--- a/tests/test_embed_phase.py
+++ b/tests/test_embed_phase.py
@@ -220,6 +220,50 @@ class TestEmbedPhase:
         assert mock_embed.call_count <= 10
 
     @patch("jobbuddy.sync.embed.embed_texts")
+    def test_poison_pill_does_not_punish_batchmates(self, mock_embed, pg_conninfo):
+        """One bad record in a batch must not prevent its healthy batchmates
+        from being embedded. Reviewer-requested regression test.
+
+        Old behavior: `_process_batch` failed with one bad job in the batch
+        → every job in the batch got `failures[] += 1` → after MAX_RETRIES
+        of recurring unordered batches, all batchmates got skipped alongside
+        the poison. On a small dataset this silently lost healthy embeddings.
+
+        New behavior: bisection isolates the poison pill; healthy jobs get
+        embedded in the half that doesn't contain the bad record, and only
+        the culprit accumulates retry count.
+        """
+        _seed_embed_ready(pg_conninfo, "acme", [
+            (str(i), f"job text {i}") for i in range(5)
+        ])
+
+        def selective_fail(texts: list[str]):
+            # "poison" appears only in job 0's stripped text
+            if any("acme-0" in t for t in texts):
+                raise Exception("poison pill")
+            return _fake_embed(texts)
+
+        mock_embed.side_effect = selective_fail
+
+        display = PhaseState("Embed")
+        EmbedPhase(pg_conninfo, display=display).run()
+
+        # All four healthy jobs should end up embedded; only the poison pill
+        # gets skipped after MAX_RETRIES.
+        store = JobStore(pg_conninfo)
+        embedded_ids = {
+            r["job_id"] for r in store.conn.execute(
+                """SELECT j.job_id FROM job_embeddings e
+                   JOIN jobs j ON e.job_id = j.id"""
+            ).fetchall()
+        }
+        store.close()
+        assert embedded_ids == {"1", "2", "3", "4"}, (
+            f"poison pill took batchmates down with it: embedded={embedded_ids}"
+        )
+        assert display.status == "idle"
+
+    @patch("jobbuddy.sync.embed.embed_texts")
     def test_transient_failure_then_recovery(self, mock_embed, pg_conninfo):
         """A single transient failure doesn't prevent successful embedding on retry."""
         _seed_embed_ready(pg_conninfo, "acme", [

--- a/tests/test_embed_phase.py
+++ b/tests/test_embed_phase.py
@@ -1,0 +1,290 @@
+"""Tests for EmbedPhase — single-threaded embed pipeline.
+
+The embed phase runs one synchronous loop (poll → embed → write → repeat).
+It is intentionally single-threaded: embed_texts() saturates the provider's
+TPM quota from a single worker via header-based pacing, and going wider
+was the source of a prefetch/dedupe bug that re-embedded jobs several
+times per run.
+
+These tests lock in:
+- Each eligible job is embedded exactly once, even when upstream_done is
+  still firing (the regression).
+- Happy path, slug filter, empty-work, retry, and recovery behaviors.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+from jobbuddy.store import JobStore
+from jobbuddy.sync.display import PhaseState
+from jobbuddy.sync.embed import EmbedPhase
+
+from conftest import make_job, seed_jobs
+
+
+def _seed_embed_ready(conninfo: str, slug: str, jobs: list[tuple[str, str]]) -> None:
+    """Seed jobs with description_stripped set so EmbedPhase will pick them up."""
+    seed_jobs(conninfo, slug, [
+        make_job(jid, title=f"{slug}-{jid}", description=desc)
+        for jid, desc in jobs
+    ])
+    store = JobStore(conninfo)
+    for jid, _ in jobs:
+        row = store.conn.execute(
+            "SELECT id FROM jobs WHERE company_slug = %s AND job_id = %s",
+            (slug, jid),
+        ).fetchone()
+        store.update_stripped_description(row["id"], f"stripped text for {slug}-{jid}")
+    store.close()
+
+
+def _fake_embed(texts: list[str]) -> tuple[list[list[float]], int]:
+    """Deterministic fake for embed_texts: 1536-dim zero vectors."""
+    return [[0.0] * 1536 for _ in texts], len(texts) * 100
+
+
+class TestEmbedPhase:
+    @patch("jobbuddy.sync.embed.embed_texts")
+    def test_embeds_all_ready_jobs_exactly_once(self, mock_embed, pg_conninfo):
+        """Happy path: each eligible job is embedded exactly once."""
+        _seed_embed_ready(pg_conninfo, "acme", [
+            ("1", "first job"),
+            ("2", "second job"),
+            ("3", "third job"),
+        ])
+        mock_embed.side_effect = _fake_embed
+
+        display = PhaseState("Embed")
+        EmbedPhase(pg_conninfo, display=display).run()
+
+        # Collect every text ever passed to embed_texts across all calls
+        all_texts: list[str] = []
+        for call in mock_embed.call_args_list:
+            all_texts.extend(call.args[0])
+
+        assert len(all_texts) == 3, f"expected 3 embeddings, got {len(all_texts)}"
+        assert len(set(all_texts)) == 3, "duplicate texts sent to embed_texts"
+
+        store = JobStore(pg_conninfo)
+        n = store.conn.execute(
+            "SELECT COUNT(*) AS c FROM job_embeddings"
+        ).fetchone()["c"]
+        store.close()
+        assert n == 3
+
+        assert display.done == 3
+        assert display.errors == 0
+        assert display.status == "idle"
+
+    @patch("jobbuddy.sync.embed.embed_texts")
+    @patch("jobbuddy.sync.embed.compute_batch_size", return_value=3)
+    def test_no_re_embed_while_upstream_still_running(
+        self, mock_bs, mock_embed, pg_conninfo,
+    ):
+        """REGRESSION: embed phase must not re-embed jobs while upstream_done is unset.
+
+        The old queue+prefetch design would re-dispatch in-flight jobs as a
+        fresh batch tuple on each poll, causing duplicate API calls per job.
+        Trigger conditions:
+          - Small batch size (3) so multiple batches are needed for 10 jobs.
+          - Slow embed (0.3s) so the producer re-polls mid-processing.
+          - upstream_done unset so the producer loop keeps going instead of
+            bailing on the first empty poll.
+
+        Under the old code, the first batch (j1..j3) gets dispatched; before
+        the worker commits, the producer re-polls with LIMIT = 3 + len(dispatched),
+        gets a different-sized row set (j1..j4), builds a fresh tuple key
+        (1,2,3,4) that the in-memory dedupe set doesn't recognize, and queues
+        it — re-embedding j1..j3. The simplified single-threaded loop embeds
+        each job exactly once regardless of poll frequency.
+        """
+        _seed_embed_ready(pg_conninfo, "acme", [
+            (f"{i}", f"job text {i}") for i in range(10)
+        ])
+
+        def slow_embed(texts: list[str]):
+            time.sleep(0.3)
+            return _fake_embed(texts)
+
+        mock_embed.side_effect = slow_embed
+
+        upstream_done = threading.Event()
+        display = PhaseState("Embed")
+        phase = EmbedPhase(
+            pg_conninfo, display=display, upstream_done=upstream_done,
+        )
+
+        def signal_later():
+            time.sleep(2.5)
+            upstream_done.set()
+
+        threading.Thread(target=signal_later, daemon=True).start()
+        phase.run()
+
+        all_texts: list[str] = []
+        for call in mock_embed.call_args_list:
+            all_texts.extend(call.args[0])
+
+        assert len(all_texts) == 10, (
+            f"expected exactly 10 embed_texts entries (one per job), "
+            f"got {len(all_texts)} — duplicates indicate the prefetch race is back"
+        )
+        assert len(set(all_texts)) == 10
+
+        store = JobStore(pg_conninfo)
+        n = store.conn.execute(
+            "SELECT COUNT(*) AS c FROM job_embeddings"
+        ).fetchone()["c"]
+        store.close()
+        assert n == 10
+
+    @patch("jobbuddy.sync.embed.embed_texts")
+    def test_respects_slug_filter(self, mock_embed, pg_conninfo):
+        """Only jobs matching the slugs filter get embedded."""
+        _seed_embed_ready(pg_conninfo, "acme", [("1", "acme job")])
+        _seed_embed_ready(pg_conninfo, "beta", [("2", "beta job")])
+
+        mock_embed.side_effect = _fake_embed
+
+        display = PhaseState("Embed")
+        EmbedPhase(pg_conninfo, display=display, slugs=["acme"]).run()
+
+        all_texts: list[str] = []
+        for call in mock_embed.call_args_list:
+            all_texts.extend(call.args[0])
+
+        assert any("acme" in t for t in all_texts)
+        assert not any("beta" in t for t in all_texts)
+
+        store = JobStore(pg_conninfo)
+        acme_embeddings = store.conn.execute(
+            """SELECT COUNT(*) AS c FROM job_embeddings e
+               JOIN jobs j ON e.job_id = j.id
+               WHERE j.company_slug = 'acme'"""
+        ).fetchone()["c"]
+        beta_embeddings = store.conn.execute(
+            """SELECT COUNT(*) AS c FROM job_embeddings e
+               JOIN jobs j ON e.job_id = j.id
+               WHERE j.company_slug = 'beta'"""
+        ).fetchone()["c"]
+        store.close()
+        assert acme_embeddings == 1
+        assert beta_embeddings == 0
+
+    @patch("jobbuddy.sync.embed.embed_texts")
+    def test_empty_work_no_upstream_returns_immediately(self, mock_embed, pg_conninfo):
+        """No work and no upstream producer → phase skips without calling embed."""
+        display = PhaseState("Embed")
+        EmbedPhase(pg_conninfo, display=display).run()
+        mock_embed.assert_not_called()
+        # Phase never transitions to active when there's nothing to do
+        assert display.status == "pending"
+
+    @patch("jobbuddy.sync.embed.embed_texts")
+    def test_empty_work_upstream_done_returns_immediately(self, mock_embed, pg_conninfo):
+        """Upstream already finished with zero work → phase exits cleanly."""
+        upstream_done = threading.Event()
+        upstream_done.set()
+        display = PhaseState("Embed")
+        EmbedPhase(
+            pg_conninfo, display=display, upstream_done=upstream_done,
+        ).run()
+        mock_embed.assert_not_called()
+        assert display.status == "pending"
+
+    @patch("jobbuddy.sync.embed.embed_texts")
+    def test_persistent_failure_gives_up_after_max_retries(
+        self, mock_embed, pg_conninfo
+    ):
+        """A job that keeps failing is eventually given up on so the phase can finish."""
+        _seed_embed_ready(pg_conninfo, "acme", [("1", "first")])
+        mock_embed.side_effect = Exception("API down")
+
+        display = PhaseState("Embed")
+        EmbedPhase(pg_conninfo, display=display).run()
+
+        # Phase must complete (not loop forever)
+        assert display.status == "idle"
+        assert display.errors >= 1
+
+        store = JobStore(pg_conninfo)
+        n = store.conn.execute(
+            "SELECT COUNT(*) AS c FROM job_embeddings"
+        ).fetchone()["c"]
+        store.close()
+        assert n == 0
+        # Retries should cap somewhere reasonable
+        assert mock_embed.call_count <= 10
+
+    @patch("jobbuddy.sync.embed.embed_texts")
+    def test_transient_failure_then_recovery(self, mock_embed, pg_conninfo):
+        """A single transient failure doesn't prevent successful embedding on retry."""
+        _seed_embed_ready(pg_conninfo, "acme", [
+            ("1", "first"),
+            ("2", "second"),
+        ])
+
+        call_count = {"n": 0}
+
+        def flaky(texts: list[str]):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise Exception("transient network blip")
+            return _fake_embed(texts)
+
+        mock_embed.side_effect = flaky
+
+        display = PhaseState("Embed")
+        EmbedPhase(pg_conninfo, display=display).run()
+
+        store = JobStore(pg_conninfo)
+        n = store.conn.execute(
+            "SELECT COUNT(*) AS c FROM job_embeddings"
+        ).fetchone()["c"]
+        store.close()
+        assert n == 2
+        assert display.errors == 1
+        assert display.done == 2
+        assert display.status == "idle"
+
+    @patch("jobbuddy.sync.embed.embed_texts")
+    def test_late_arrivals_picked_up_while_upstream_open(
+        self, mock_embed, pg_conninfo
+    ):
+        """Jobs added after the phase starts are picked up before upstream_done."""
+        mock_embed.side_effect = _fake_embed
+
+        upstream_done = threading.Event()
+        display = PhaseState("Embed")
+
+        # Seed initial work so the phase enters its main loop
+        _seed_embed_ready(pg_conninfo, "acme", [("1", "first job")])
+
+        phase = EmbedPhase(
+            pg_conninfo, display=display, upstream_done=upstream_done,
+        )
+
+        def add_more_then_finish():
+            time.sleep(0.3)
+            _seed_embed_ready(pg_conninfo, "acme", [("2", "second job")])
+            time.sleep(0.3)
+            upstream_done.set()
+
+        threading.Thread(target=add_more_then_finish, daemon=True).start()
+        phase.run()
+
+        all_texts: list[str] = []
+        for call in mock_embed.call_args_list:
+            all_texts.extend(call.args[0])
+        assert len(all_texts) == 2
+        assert len(set(all_texts)) == 2
+
+        store = JobStore(pg_conninfo)
+        n = store.conn.execute(
+            "SELECT COUNT(*) AS c FROM job_embeddings"
+        ).fetchone()["c"]
+        store.close()
+        assert n == 2


### PR DESCRIPTION
## Summary

- EmbedPhase's producer/consumer dispatch had a race that re-embedded each job 3–4× per sync, inflating the embed phase done count, burning API tokens, and doing redundant DELETE+INSERT writes for embeddings that were already correct.
- Root cause: the in-memory dedup set was keyed on the whole-batch **tuple** (`tuple(job_ids)`), not individual job ids. When the producer polled ahead of a slow worker, the DB returned a slightly different row set — new tuple shape, not in `dispatched`, dispatched as fresh work. The worker then re-embedded every overlapping job.
- Fix: replace the `WorkerPhase`-based EmbedPhase with a plain single-threaded loop (poll → embed → write → repeat). `embed_texts()` already saturates the TPM quota from one worker via header-based pacing (`x-ratelimit-remaining-tokens`), so the parallel machinery wasn't buying throughput — only correctness bugs.

## What was removed

- `work_queue` + prefetch window (`maxsize = max_workers * 2`)
- `dispatched: set[Hashable]` and the over-fetch trick
- `ThreadPoolExecutor` worker loop
- The broken tuple-based `item_key`
- Inheriting from `WorkerPhase` at all — EmbedPhase is now a plain class with a matching constructor signature

## What stayed the same

- Same constructor signature used by `sync/__init__.py` (`conninfo, display, slugs, upstream_done`)
- Runs concurrently with strip/enrich at the pipeline level (it's still its own phase thread)
- `upstream_done` event chain honored — keeps polling while strip is producing
- `PhaseState` updates (`start`, `advance`, `record_error`, `finish`, token counter, active_workers)
- Per-job retry with `MAX_RETRIES` — now keyed on **job pk** instead of batch tuple, so retries actually work
- Rate-limit pacing (still happens inside `embed_texts()`)

## Regression test

`tests/test_embed_phase.py::test_no_re_embed_while_upstream_still_running` reproduces the exact race:

- Forces `compute_batch_size() = 3` so 10 jobs need multiple batches
- Mocks `embed_texts()` with a 0.3s sleep to widen the race window
- Leaves `upstream_done` unset so the producer loop keeps going instead of bailing on an empty poll
- Asserts every job appears exactly once across all `embed_texts` calls

Against the old code: **40 embed_texts entries for 10 jobs** (4× duplication — matches the production signal).
Against the new code: **exactly 10**.

## Test plan

- [x] New `tests/test_embed_phase.py` (8 tests): happy path, regression, slug filter, empty-work fast-skip (both with and without upstream_done), persistent-failure giveup, transient-failure recovery, late arrivals
- [x] Full suite green: 165 passed
- [ ] Watch the next scheduled sync (systemd timer `jsb-sync.timer`) — the "Embed phase done (N done)" count should land near strip's output rather than 3–4× it

## Trade-off / future-proofing

No intra-phase parallelism. If you ever switch to a provider that can't hit its TPM budget from a single worker, re-introduce a dispatcher — but key dedup on **individual job ids**, not batch tuples. The `sync/embed.py` module docstring calls this out explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)