### PR TITLE
Add Phenom People ATS fetcher

### DIFF
--- a/src/jobbuddy/fetchers/__init__.py
+++ b/src/jobbuddy/fetchers/__init__.py
@@ -9,6 +9,7 @@ from jobbuddy.fetchers.greenhouse import GreenhouseFetcher
 from jobbuddy.fetchers.lever import LeverFetcher
 from jobbuddy.fetchers.oracle_hcm import OracleHCMFetcher
 from jobbuddy.fetchers.paylocity import PaylocityFetcher
+from jobbuddy.fetchers.phenom import PhenomFetcher
 from jobbuddy.fetchers.rippling import RipplingFetcher
 from jobbuddy.fetchers.talentbrew import TalentBrewFetcher
 from jobbuddy.fetchers.workable import WorkableFetcher
@@ -24,6 +25,7 @@ _REGISTRY: dict[str, type[ATSFetcher]] = {
     "lever": LeverFetcher,
     "oracle_hcm": OracleHCMFetcher,
     "paylocity": PaylocityFetcher,
+    "phenom": PhenomFetcher,
     "rippling": RipplingFetcher,
     "talentbrew": TalentBrewFetcher,
     "workable": WorkableFetcher,

--- a/src/jobbuddy/fetchers/phenom.py
+++ b/src/jobbuddy/fetchers/phenom.py
@@ -1,0 +1,205 @@
+"""Phenom People ATS fetcher.
+
+Used by BAE Systems, RTX/Raytheon, GE Aerospace, Collins Aerospace, etc.
+All requests go to POST https://{careers_domain}/widgets with a JSON body
+specifying the DDO key (refineSearch for listings, jobDetail for details).
+"""
+
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import date
+
+from jobbuddy.fetchers.base import ATSFetcher, JobList, ProgressCallback, RetryCallback
+from jobbuddy.models import Job, strip_html
+
+log = logging.getLogger(__name__)
+
+PAGE_SIZE = 20
+
+
+def _parse_posted_date(value: str | None) -> date | None:
+    """Parse Phenom ISO timestamp (e.g. '2026-02-02T16:02:16.519+0000') to date."""
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+class PhenomFetcher(ATSFetcher):
+    ats_type = "phenom"
+    descriptions_in_listing = False
+    enrich_delay = 0.0
+
+    def __init__(
+        self,
+        board: str,
+        name: str | None = None,
+        *,
+        careers_url: str = "",
+        locale: str = "en_global",
+        country: str = "global",
+        page_id: str = "page1-migration",
+    ):
+        super().__init__(board, name)
+        self.careers_url = careers_url.rstrip("/")
+        self.locale = locale
+        self.country = country
+        self.page_id = page_id
+        if self.careers_url:
+            self.client.headers["Origin"] = self.careers_url
+            self.client.headers["Referer"] = f"{self.careers_url}/{self.country}/{self._locale_short()}/search-results"
+
+    def _locale_short(self) -> str:
+        """Extract the language code from locale (e.g. 'en_global' -> 'en')."""
+        return self.locale.split("_")[0] if "_" in self.locale else self.locale
+
+    def _require_config(self) -> None:
+        if not self.careers_url:
+            raise ValueError(
+                f"Phenom fetcher for '{self.board}' requires careers_url. "
+                "This is normally set from the company registry."
+            )
+
+    def _widgets_url(self) -> str:
+        return f"{self.careers_url}/widgets"
+
+    def _job_url(self, job_id: str) -> str:
+        return f"{self.careers_url}/{self.country}/{self._locale_short()}/job/{job_id}"
+
+    def _refine_search_body(self, offset: int) -> dict:
+        return {
+            "lang": self.locale,
+            "deviceType": "desktop",
+            "country": self.country,
+            "pageName": "search-results",
+            "ddoKey": "refineSearch",
+            "sortBy": "",
+            "substring": "",
+            "from": offset,
+            "jobs": True,
+            "counts": True,
+            "all_fields": ["category", "country", "state", "city", "type", "subCategory"],
+            "size": PAGE_SIZE,
+            "clearAll": False,
+            "jdsource": "facets",
+            "isSlider": False,
+            "pageId": self.page_id,
+            "siteType": "external",
+            "keywords": "",
+        }
+
+    def _job_detail_body(self, job_id: str) -> dict:
+        return {
+            "lang": self.locale,
+            "deviceType": "desktop",
+            "country": self.country,
+            "pageName": "job",
+            "ddoKey": "jobDetail",
+            "jobId": job_id,
+            "siteType": "external",
+            "pageId": self.page_id,
+        }
+
+    def _parse_listing(self, raw: dict) -> Job:
+        """Map a job object from refineSearch response to a Job."""
+        job_id = raw.get("jobId", "")
+        return Job(
+            id=job_id,
+            title=raw.get("title", ""),
+            location=raw.get("location", ""),
+            url=self._job_url(job_id),
+            apply_url=raw.get("applyUrl", self._job_url(job_id)),
+            published_at=_parse_posted_date(raw.get("postedDate")),
+            department=raw.get("category"),
+        )
+
+    def list_jobs(
+        self,
+        *,
+        on_progress: ProgressCallback | None = None,
+        on_retry: RetryCallback | None = None,
+    ) -> JobList:
+        self._require_config()
+        url = self._widgets_url()
+
+        # Fetch page 0 to learn total
+        resp = self.client.post(url, json=self._refine_search_body(0))
+        resp.raise_for_status()
+        data = resp.json()
+
+        refine = data.get("refineSearch", {})
+        total = refine.get("totalHits", 0)
+        raw_jobs = refine.get("data", {}).get("jobs", [])
+        jobs: JobList = [self._parse_listing(j) for j in raw_jobs]
+
+        if on_progress:
+            on_progress(len(jobs), total)
+
+        # Use actual page size from first response for offset calculation —
+        # the API may return fewer items than the requested `size`.
+        page_size = len(raw_jobs) or PAGE_SIZE
+        remaining_offsets = list(range(page_size, total, page_size))
+        if not remaining_offsets:
+            return jobs
+
+        lock = threading.Lock()
+
+        def _fetch_page(offset: int) -> list[Job]:
+            page_resp = self.client.post(url, json=self._refine_search_body(offset))
+            page_resp.raise_for_status()
+            page_data = page_resp.json()
+            page_refine = page_data.get("refineSearch", {})
+            page_jobs = page_refine.get("data", {}).get("jobs", [])
+            return [self._parse_listing(j) for j in page_jobs]
+
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = {executor.submit(_fetch_page, off): off for off in remaining_offsets}
+            for future in as_completed(futures):
+                page_jobs = future.result()
+                with lock:
+                    jobs.extend(page_jobs)
+                    current = len(jobs)
+                if on_progress:
+                    on_progress(current, total)
+
+        return jobs
+
+    def _fetch_detail(self, job_id: str) -> dict:
+        """Fetch job detail from the jobDetail DDO."""
+        resp = self.client.post(self._widgets_url(), json=self._job_detail_body(job_id))
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("jobDetail", {}).get("data", {}).get("job", {})
+
+    def fetch_job(self, job_id: str) -> Job:
+        self._require_config()
+        job_data = self._fetch_detail(job_id)
+
+        if not job_data or not job_data.get("jobId"):
+            raise ValueError(f"Job {job_id} not found on {self.board} board.")
+
+        description = job_data.get("description", "")
+        if description:
+            description = strip_html(description)
+
+        return Job(
+            id=job_data["jobId"],
+            title=job_data.get("title", ""),
+            location=job_data.get("location", ""),
+            url=self._job_url(job_data["jobId"]),
+            apply_url=job_data.get("applyUrl", self._job_url(job_data["jobId"])),
+            published_at=_parse_posted_date(job_data.get("postedDate")),
+            department=job_data.get("category"),
+            salary=job_data.get("payRange"),
+            description=description or None,
+        )
+
+    def fetch_description(self, job_id: str, metadata: dict | None = None) -> str | None:
+        """Fetch description directly from detail API (for enrichment)."""
+        self._require_config()
+        job_data = self._fetch_detail(job_id)
+        desc = job_data.get("description", "")
+        return strip_html(desc) if desc else None

--- a/src/jobbuddy/fetchers/phenom.py
+++ b/src/jobbuddy/fetchers/phenom.py
@@ -125,10 +125,12 @@ class PhenomFetcher(ATSFetcher):
         self._require_config()
         url = self._widgets_url()
 
-        # Fetch page 0 to learn total
-        resp = self.client.post(url, json=self._refine_search_body(0))
-        resp.raise_for_status()
-        data = resp.json()
+        def _fetch_page0():
+            resp = self.client.post(url, json=self._refine_search_body(0))
+            resp.raise_for_status()
+            return resp.json()
+
+        data = self._retry_request(_fetch_page0, on_retry=on_retry)
 
         refine = data.get("refineSearch", {})
         total = refine.get("totalHits", 0)
@@ -138,22 +140,21 @@ class PhenomFetcher(ATSFetcher):
         if on_progress:
             on_progress(len(jobs), total)
 
-        # Use actual page size from first response for offset calculation —
-        # the API may return fewer items than the requested `size`.
-        page_size = len(raw_jobs) or PAGE_SIZE
-        remaining_offsets = list(range(page_size, total, page_size))
+        remaining_offsets = list(range(PAGE_SIZE, total, PAGE_SIZE))
         if not remaining_offsets:
             return jobs
 
         lock = threading.Lock()
 
         def _fetch_page(offset: int) -> list[Job]:
-            page_resp = self.client.post(url, json=self._refine_search_body(offset))
-            page_resp.raise_for_status()
-            page_data = page_resp.json()
-            page_refine = page_data.get("refineSearch", {})
-            page_jobs = page_refine.get("data", {}).get("jobs", [])
-            return [self._parse_listing(j) for j in page_jobs]
+            def _do_fetch():
+                page_resp = self.client.post(url, json=self._refine_search_body(offset))
+                page_resp.raise_for_status()
+                page_data = page_resp.json()
+                page_refine = page_data.get("refineSearch", {})
+                page_jobs = page_refine.get("data", {}).get("jobs", [])
+                return [self._parse_listing(j) for j in page_jobs]
+            return self._retry_request(_do_fetch, on_retry=on_retry)
 
         with ThreadPoolExecutor(max_workers=5) as executor:
             futures = {executor.submit(_fetch_page, off): off for off in remaining_offsets}

--- a/src/jobbuddy/url.py
+++ b/src/jobbuddy/url.py
@@ -323,6 +323,41 @@ def _parse_avature(url: str) -> ParsedURL | None:
 
 
 # ---------------------------------------------------------------------------
+# Phenom People (BAE Systems, RTX, GE Aerospace, etc.)
+# ---------------------------------------------------------------------------
+# https://{careers_domain}/{country}/{locale}/job/{jobId}
+# https://{careers_domain}/{country}/{locale}/job/{jobId}/{slug}
+
+def _parse_phenom(url: str) -> ParsedURL | None:
+    parsed = urlparse(url)
+    path = parsed.path
+    host = parsed.hostname or ""
+
+    # Match /{country_code}/{locale}/job/{jobId} in path
+    m = re.search(r"/([a-z]{2,})/([a-z]{2})/job/([^/]+)", path, re.IGNORECASE)
+    if not m:
+        return None
+
+    job_id = m.group(3)
+
+    # Reverse-lookup: find the phenom company whose careers_url matches this host
+    from jobbuddy.registry import load_registry
+
+    for slug, company in load_registry().items():
+        if company.ats != "phenom":
+            continue
+        extras = company.model_extra or {}
+        careers_url = extras.get("careers_url", "")
+        if not careers_url:
+            continue
+        careers_host = urlparse(careers_url).hostname or ""
+        if careers_host == host:
+            return ParsedURL(ats="phenom", board=slug, job_id=job_id)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
 # TalentBrew (Radancy)
 # ---------------------------------------------------------------------------
 # https://jobs.intuit.com/job/{location}/{title}/{tenant_id}/{job_id}
@@ -354,6 +389,7 @@ _PARSERS = [
     _parse_oracle_hcm,
     _parse_paylocity,
     _parse_avature,
+    _parse_phenom,
     _parse_talentbrew,
 ]
 

--- a/tests/test_phenom.py
+++ b/tests/test_phenom.py
@@ -1,0 +1,428 @@
+"""Tests for Phenom People ATS fetcher and URL parsing."""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from jobbuddy.fetchers.phenom import PhenomFetcher
+from jobbuddy.url import parse_url
+
+
+# ---------------------------------------------------------------------------
+# Sample API responses
+# ---------------------------------------------------------------------------
+
+REFINE_SEARCH_PAGE_0 = {
+    "refineSearch": {
+        "status": 200,
+        "hits": 2,
+        "totalHits": 3,
+        "data": {
+            "jobs": [
+                {
+                    "jobId": "120644BR",
+                    "title": "Assembler I- Clean Room",
+                    "location": "Endicott, New York, United States",
+                    "category": "Manufacturing & Maintenance",
+                    "postedDate": "2026-02-02T16:02:16.519+0000",
+                    "applyUrl": "https://sjobs.brassring.com/apply/120644BR",
+                    "type": "Full-Time",
+                    "descriptionTeaser": "Join our team as...",
+                    "reqId": "120644BR",
+                    "jobSeqNo": "BAE1US120644BREXTERNAL",
+                },
+                {
+                    "jobId": "130999XY",
+                    "title": "Software Engineer II",
+                    "location": "Arlington, Virginia, United States",
+                    "category": "Engineering",
+                    "postedDate": "2026-03-15T10:00:00.000+0000",
+                    "applyUrl": "https://sjobs.brassring.com/apply/130999XY",
+                    "type": "Full-Time",
+                    "descriptionTeaser": "Build cool things...",
+                    "reqId": "130999XY",
+                    "jobSeqNo": "BAE1US130999XYEXTERNAL",
+                },
+            ],
+        },
+    },
+}
+
+REFINE_SEARCH_PAGE_1 = {
+    "refineSearch": {
+        "status": 200,
+        "hits": 1,
+        "totalHits": 3,
+        "data": {
+            "jobs": [
+                {
+                    "jobId": "140111ZZ",
+                    "title": "Program Manager",
+                    "location": "Dallas, Texas, United States",
+                    "category": "Program Management",
+                    "postedDate": "2026-04-01T08:30:00.000+0000",
+                    "applyUrl": "https://sjobs.brassring.com/apply/140111ZZ",
+                    "type": "Full-Time",
+                    "descriptionTeaser": "Lead programs...",
+                    "reqId": "140111ZZ",
+                    "jobSeqNo": "BAE1US140111ZZEXTERNAL",
+                },
+            ],
+        },
+    },
+}
+
+JOB_DETAIL_RESPONSE = {
+    "jobDetail": {
+        "status": 200,
+        "data": {
+            "job": {
+                "jobId": "120644BR",
+                "title": "Assembler I- Clean Room",
+                "location": "Endicott, New York, United States",
+                "category": "Manufacturing & Maintenance",
+                "postedDate": "2026-02-02T16:02:16.519+0000",
+                "applyUrl": "https://sjobs.brassring.com/apply/120644BR",
+                "description": "<p>This is the <b>full</b> job description.</p>",
+                "payRange": "$20-$30/hr",
+                "type": "Full-Time",
+            },
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_phenom_fetcher(**overrides) -> PhenomFetcher:
+    defaults = dict(
+        board="bae-systems",
+        name="BAE Systems",
+        careers_url="https://jobs.baesystems.com",
+    )
+    defaults.update(overrides)
+    board = defaults.pop("board")
+    name = defaults.pop("name")
+    f = PhenomFetcher(board, name, **defaults)
+    f.client = MagicMock()
+    f.backoff_base = 0.01
+    return f
+
+
+def mock_post_response(json_data, status_code=200):
+    resp = MagicMock()
+    resp.json.return_value = json_data
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# list_jobs tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhenomListJobs:
+    def test_single_page(self):
+        """list_jobs parses a single-page response correctly."""
+        fetcher = make_phenom_fetcher()
+        # totalHits = 2 with page size 2 => single page
+        single_page = {
+            "refineSearch": {
+                "status": 200,
+                "hits": 2,
+                "totalHits": 2,
+                "data": {
+                    "jobs": REFINE_SEARCH_PAGE_0["refineSearch"]["data"]["jobs"][:2],
+                },
+            },
+        }
+        fetcher.client.post.return_value = mock_post_response(single_page)
+
+        jobs = fetcher.list_jobs()
+
+        assert len(jobs) == 2
+        assert jobs[0].id == "120644BR"
+        assert jobs[0].title == "Assembler I- Clean Room"
+        assert jobs[0].location == "Endicott, New York, United States"
+        assert jobs[0].department == "Manufacturing & Maintenance"
+        assert jobs[0].published_at == date(2026, 2, 2)
+        assert jobs[0].url == "https://jobs.baesystems.com/global/en/job/120644BR"
+        assert jobs[0].description is None  # stub fetcher
+
+    def test_pagination(self):
+        """list_jobs paginates through multiple pages."""
+        fetcher = make_phenom_fetcher()
+        fetcher.client.post.side_effect = [
+            mock_post_response(REFINE_SEARCH_PAGE_0),
+            mock_post_response(REFINE_SEARCH_PAGE_1),
+        ]
+
+        jobs = fetcher.list_jobs()
+
+        assert len(jobs) == 3
+        ids = {j.id for j in jobs}
+        assert ids == {"120644BR", "130999XY", "140111ZZ"}
+
+    def test_progress_callback(self):
+        """list_jobs calls on_progress with (fetched, total)."""
+        fetcher = make_phenom_fetcher()
+        single_page = {
+            "refineSearch": {
+                "status": 200,
+                "hits": 1,
+                "totalHits": 1,
+                "data": {
+                    "jobs": [REFINE_SEARCH_PAGE_0["refineSearch"]["data"]["jobs"][0]],
+                },
+            },
+        }
+        fetcher.client.post.return_value = mock_post_response(single_page)
+
+        progress = []
+        jobs = fetcher.list_jobs(on_progress=lambda f, t: progress.append((f, t)))
+
+        assert len(jobs) == 1
+        assert progress[-1] == (1, 1)
+
+    def test_empty_response(self):
+        """list_jobs handles zero results gracefully."""
+        fetcher = make_phenom_fetcher()
+        empty = {
+            "refineSearch": {
+                "status": 200,
+                "hits": 0,
+                "totalHits": 0,
+                "data": {"jobs": []},
+            },
+        }
+        fetcher.client.post.return_value = mock_post_response(empty)
+
+        jobs = fetcher.list_jobs()
+        assert jobs == []
+
+    def test_missing_posted_date(self):
+        """Jobs with no postedDate get published_at=None."""
+        fetcher = make_phenom_fetcher()
+        no_date = {
+            "refineSearch": {
+                "status": 200,
+                "hits": 1,
+                "totalHits": 1,
+                "data": {
+                    "jobs": [
+                        {
+                            "jobId": "999",
+                            "title": "Test Job",
+                            "location": "Remote",
+                            "category": "IT",
+                        },
+                    ],
+                },
+            },
+        }
+        fetcher.client.post.return_value = mock_post_response(no_date)
+
+        jobs = fetcher.list_jobs()
+        assert jobs[0].published_at is None
+
+    def test_custom_locale_and_country(self):
+        """Custom locale/country affect job URLs."""
+        fetcher = make_phenom_fetcher(
+            locale="en_us",
+            country="us",
+        )
+        single_page = {
+            "refineSearch": {
+                "status": 200,
+                "hits": 1,
+                "totalHits": 1,
+                "data": {
+                    "jobs": [REFINE_SEARCH_PAGE_0["refineSearch"]["data"]["jobs"][0]],
+                },
+            },
+        }
+        fetcher.client.post.return_value = mock_post_response(single_page)
+
+        jobs = fetcher.list_jobs()
+        assert jobs[0].url == "https://jobs.baesystems.com/us/en/job/120644BR"
+
+
+# ---------------------------------------------------------------------------
+# fetch_job tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhenomFetchJob:
+    def test_fetch_job_detail(self):
+        """fetch_job retrieves full details from the detail API."""
+        fetcher = make_phenom_fetcher()
+        fetcher.client.post.return_value = mock_post_response(JOB_DETAIL_RESPONSE)
+
+        job = fetcher.fetch_job("120644BR")
+
+        assert job.id == "120644BR"
+        assert job.title == "Assembler I- Clean Room"
+        assert job.location == "Endicott, New York, United States"
+        assert job.department == "Manufacturing & Maintenance"
+        assert "full" in job.description  # HTML stripped
+        assert "<p>" not in job.description  # HTML stripped
+        assert "<b>" not in job.description  # HTML stripped
+        assert job.salary == "$20-$30/hr"
+        assert job.published_at == date(2026, 2, 2)
+
+    def test_fetch_job_no_description(self):
+        """fetch_job handles missing description gracefully."""
+        fetcher = make_phenom_fetcher()
+        no_desc = {
+            "jobDetail": {
+                "status": 200,
+                "data": {
+                    "job": {
+                        "jobId": "120644BR",
+                        "title": "Assembler I",
+                        "location": "Endicott, NY",
+                    },
+                },
+            },
+        }
+        fetcher.client.post.return_value = mock_post_response(no_desc)
+
+        job = fetcher.fetch_job("120644BR")
+        assert job.description is None
+
+    def test_fetch_job_not_found(self):
+        """fetch_job raises ValueError when job detail is empty."""
+        fetcher = make_phenom_fetcher()
+        empty = {"jobDetail": {"status": 200, "data": {"job": {}}}}
+        fetcher.client.post.return_value = mock_post_response(empty)
+
+        with pytest.raises(ValueError, match="not found"):
+            fetcher.fetch_job("NONEXISTENT")
+
+
+# ---------------------------------------------------------------------------
+# fetch_description tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhenomFetchDescription:
+    def test_fetch_description_returns_stripped_html(self):
+        """fetch_description returns stripped HTML from detail API."""
+        fetcher = make_phenom_fetcher()
+        fetcher.client.post.return_value = mock_post_response(JOB_DETAIL_RESPONSE)
+
+        desc = fetcher.fetch_description("120644BR")
+
+        assert desc is not None
+        assert "full" in desc
+        assert "<p>" not in desc
+
+    def test_fetch_description_empty(self):
+        """fetch_description returns None when no description."""
+        fetcher = make_phenom_fetcher()
+        no_desc = {
+            "jobDetail": {
+                "status": 200,
+                "data": {
+                    "job": {
+                        "jobId": "120644BR",
+                        "title": "Test",
+                    },
+                },
+            },
+        }
+        fetcher.client.post.return_value = mock_post_response(no_desc)
+
+        desc = fetcher.fetch_description("120644BR")
+        assert desc is None
+
+
+# ---------------------------------------------------------------------------
+# Configuration validation
+# ---------------------------------------------------------------------------
+
+
+class TestPhenomConfig:
+    def test_requires_careers_url(self):
+        """Fetcher raises ValueError when careers_url is not set."""
+        fetcher = PhenomFetcher("test-board", "Test")
+        fetcher.client = MagicMock()
+
+        with pytest.raises(ValueError, match="careers_url"):
+            fetcher.list_jobs()
+
+    def test_descriptions_in_listing_is_false(self):
+        """Phenom is a stub fetcher — descriptions_in_listing = False."""
+        assert PhenomFetcher.descriptions_in_listing is False
+
+    def test_ats_type(self):
+        assert PhenomFetcher.ats_type == "phenom"
+
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+
+class TestPhenomURLParsing:
+    @pytest.fixture(autouse=True)
+    def mock_registry(self):
+        """Provide phenom companies for URL reverse-lookup without DB."""
+        from jobbuddy.models import Company
+
+        companies = {
+            "bae-systems": Company(
+                slug="bae-systems", name="BAE Systems", ats="phenom",
+                board="bae-systems", careers_url="https://jobs.baesystems.com",
+            ),
+            "rtx": Company(
+                slug="rtx", name="RTX", ats="phenom",
+                board="rtx", careers_url="https://careers.rtx.com",
+            ),
+        }
+        with patch("jobbuddy.registry.load_registry", return_value=companies):
+            yield
+
+    def test_bae_systems_url(self):
+        result = parse_url("https://jobs.baesystems.com/global/en/job/120644BR")
+        assert result is not None
+        assert result.ats == "phenom"
+        assert result.job_id == "120644BR"
+
+    def test_rtx_url(self):
+        result = parse_url("https://careers.rtx.com/global/en/job/01752889")
+        assert result is not None
+        assert result.ats == "phenom"
+        assert result.job_id == "01752889"
+
+    def test_url_with_slug_suffix(self):
+        """Phenom URLs sometimes have a slug after the job ID."""
+        result = parse_url("https://jobs.baesystems.com/global/en/job/120644BR/assembler-clean-room")
+        assert result is not None
+        assert result.ats == "phenom"
+        assert result.job_id == "120644BR"
+
+    def test_us_locale_url(self):
+        result = parse_url("https://careers.rtx.com/us/en/job/01752889")
+        assert result is not None
+        assert result.ats == "phenom"
+        assert result.job_id == "01752889"
+
+    def test_non_phenom_url_not_matched(self):
+        """Non-phenom URLs should not match the phenom parser."""
+        result = parse_url("https://boards.greenhouse.io/acme/jobs/123")
+        assert result is not None
+        assert result.ats == "greenhouse"
+
+    def test_random_url_not_matched(self):
+        result = parse_url("https://example.com/global/en/job/123")
+        # Should not match (hostname not in registry)
+        # This may return None or match another parser — either is fine
+        # as long as it doesn't falsely match as phenom
+        if result is not None:
+            assert result.ats != "phenom"


### PR DESCRIPTION
## Summary

- New stub fetcher for Phenom People ATS (`src/jobbuddy/fetchers/phenom.py`)
- Scrapes career sites via `POST /widgets` API — `refineSearch` DDO for listings, `jobDetail` DDO for full descriptions
- Threaded pagination (5 workers) for large boards
- URL parser with registry reverse-lookup (same pattern as Eightfold)
- Registered in fetcher factory

Covers 4 companies: BAE Systems, RTX/Raytheon, GE Aerospace, Collins Aerospace

## What's in the change

| File | What |
|------|------|
| `src/jobbuddy/fetchers/phenom.py` | PhenomFetcher — stub fetcher with `list_jobs()`, `fetch_job()`, `fetch_description()` |
| `src/jobbuddy/fetchers/__init__.py` | Register phenom in fetcher factory |
| `src/jobbuddy/url.py` | `_parse_phenom()` URL parser |
| `tests/test_phenom.py` | 20 tests covering listing, detail, config, URL parsing |

## Design decisions

- **Stub fetcher** (`descriptions_in_listing = False`) — listing API only returns teasers, not full descriptions. Enrichment phase fetches descriptions via jobDetail DDO.
- **careers_url as config** — each Phenom company needs its own domain (e.g. `jobs.baesystems.com`, `careers.rtx.com`). Passed via Company model_extra, same pattern as Workday's `wd_company`/`wd_instance`.
- **Widget API bypasses Cloudflare** — the JSON API works even when the HTML page is CF-protected (verified on RTX).

## Test plan

- [ ] Verify tests pass with DB available (`uv run python -m pytest tests/test_phenom.py -v`)
- [ ] Register a Phenom company and run `jsb sync fetch --company <name>` to verify real API integration
- [ ] Verify enrichment works: `jsb sync enrich --company <name>`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)