### PR TITLE
Add PostgreSQL full-text search as keyword complement to vector search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,14 @@
 This is the canonical project context for AI agents working in this repository.
 CLAUDE.md points here. Read this before working on code.
 
+**The user is the human who installed the MCP server, not the LLM calling it.**
+When analyzing usage, designing parameters, writing descriptions, or prioritizing
+work — start from what the human was trying to do and whether they got a good
+outcome. It's easy to look at how the LLM called us and ask "how can we make
+this easier?" with an implicit "for the LLM." That optimizes the intermediary,
+not the outcome. The LLM is infrastructure; the human searching for jobs is
+the user.
+
 ## What This Project Is
 
 A command-line tool and MCP server for job searching: scrapes ATS job boards

--- a/src/jobbuddy/CLAUDE.md
+++ b/src/jobbuddy/CLAUDE.md
@@ -13,7 +13,10 @@ routing hints, not API docs:
 - **Server `instructions`**: Intent language ("find me jobs at...", "I applied for...").
   Name specific companies. Bias the LLM toward trying the tool first.
 - **Tool docstrings**: Lead with *when to use*, not *what it does internally*.
-- **Field `description`s**: Format hints, examples, valid values. Dense, not verbose.
+- **Field `description`s**: What the human is trying to express through this
+  parameter, then format hints. Don't teach the LLM to work around tool
+  limitations (e.g., "comma-separated for OR" teaches synonym enumeration
+  instead of intent expression).
 
 ### Human-Readable Formatting
 

--- a/src/jobbuddy/cli/search.py
+++ b/src/jobbuddy/cli/search.py
@@ -64,7 +64,7 @@ def companies_add(
 @app.command(name="list-jobs")
 def list_jobs(
     company: Optional[str] = typer.Argument(None, help="Company name or slug (omit for all cached jobs)"),
-    filter: Optional[str] = typer.Option(None, "--filter", "-f", help="Case-insensitive substring filter on job title"),
+    filter: Optional[str] = typer.Option(None, "--filter", "-f", help="Keyword search across title and description (full-text search with stemming)"),
     since: Optional[str] = typer.Option(None, "--since", "-s", help="Only show jobs posted within this period (e.g. 24h, 3d, 1w, 2w)"),
 ):
     """List open jobs from cache. Omit company for all cached jobs."""
@@ -135,7 +135,7 @@ def list_jobs(
 
 @app.command()
 def search(
-    title: Optional[str] = typer.Option(None, "--title", "-t", help="Title substring filter (comma-separated for OR)"),
+    title: Optional[str] = typer.Option(None, "--title", "-t", help="Keyword search across title and description (full-text search with stemming)"),
     location: Optional[str] = typer.Option(None, "--location", "-l", help="Location substring filter (comma-separated for OR)"),
     company: Optional[str] = typer.Option(None, "--company", "-c", help="Company name or slug"),
     exclude: Optional[str] = typer.Option(None, "--exclude", "-x", help="Comma-separated company names/slugs to exclude"),

--- a/src/jobbuddy/mcp_server.py
+++ b/src/jobbuddy/mcp_server.py
@@ -308,7 +308,7 @@ def log_job_activity(
 def search_jobs(
     company: Annotated[str, Field(default="", description="Company name or slug. Omit to search across ALL cached companies.")] = "",
     exclude_companies: Annotated[str, Field(default="", description="Comma-separated company names or slugs to exclude from results (e.g. 'microsoft,walmart,boeing'). Useful for filtering out large employers to surface smaller companies.")] = "",
-    title_filter: Annotated[str, Field(default="", description="Case-insensitive substring match on job title. Comma-separated for OR (e.g. 'product manager,PM', 'senior engineer'). Uses SQL LIKE, not regex.")] = "",
+    title_filter: Annotated[str, Field(default="", description="Keyword search across job title and description using full-text search with stemming. Describe the kind of role: 'software engineer' matches 'engineering', 'engineers', 'SDE'. Supports OR ('engineer OR scientist') and quotes ('\"machine learning\"'). No need to enumerate synonyms — stemming handles variants.")] = "",
     location_filter: Annotated[str, Field(default="", description="Case-insensitive substring match on location. Comma-separated for OR (e.g. 'seattle,remote', 'new york,NYC'). Uses SQL LIKE, not regex.")] = "",
     since: Annotated[str, Field(default="", description="Only return jobs posted within this period. Examples: '24h' (last 24 hours), '3d' (3 days), '1w' (1 week), '2w' (2 weeks).")] = "",
     query: Annotated[str, Field(default="", description="Natural language query to search job descriptions by meaning (e.g. 'kubernetes security', 'ML infrastructure'). When provided, results are ranked by semantic similarity. Combinable with company/title/location filters.")] = "",
@@ -328,13 +328,13 @@ def search_jobs(
     genuinely matching results are returned (may be fewer than the max limit for
     specific queries, which is correct behavior).
 
-    Without `query`: filters by company/title/location using keyword matching (SQL LIKE).
+    Without `query`: filters by keyword (full-text search with stemming on title + description).
     With `query`: ranks results by semantic similarity to the query text, optionally
-    filtered by company/title/location. Pass the user's words directly as the query.
+    filtered by keyword/company/location. Pass the user's words directly as the query.
 
     Company is optional — omit it to search across all ~100 cached companies.
-    Filters use case-insensitive substring matching (SQL LIKE), not regex.
-    Use commas for OR: title_filter="product manager,PM" matches either.
+    Title filter uses PostgreSQL full-text search with stemming — describe the role
+    naturally, no need to enumerate title variants. Location uses substring matching.
 
     Results include last_sync timestamp showing cache freshness, and "already applied"
     markers cross-referenced with the application log. If cache is empty, tells user
@@ -347,7 +347,7 @@ def search_jobs(
         return (
             "Error: You must provide either `title_filter` or `query` (or both). "
             "The cache has thousands of jobs — browsing without search criteria is not supported. "
-            "Examples: title_filter='product manager,PM' or query='ML infrastructure roles'."
+            "Examples: title_filter='software engineer' or query='ML infrastructure roles'."
         )
 
     # Resolve company

--- a/src/jobbuddy/migrations/008_fts_indexes.sql
+++ b/src/jobbuddy/migrations/008_fts_indexes.sql
@@ -1,0 +1,9 @@
+-- Full-text search GIN indexes for keyword search across title and description.
+-- Per-field indexes (not a single generated column) so weights can be tuned at
+-- query time without schema changes.
+
+CREATE INDEX IF NOT EXISTS idx_jobs_title_fts
+    ON jobs USING GIN (to_tsvector('english', coalesce(title, '')));
+
+CREATE INDEX IF NOT EXISTS idx_jobs_desc_fts
+    ON jobs USING GIN (to_tsvector('english', coalesce(description_stripped, '')));

--- a/src/jobbuddy/store.py
+++ b/src/jobbuddy/store.py
@@ -504,11 +504,12 @@ class JobStore:
             params.append(posted_after)
 
         if title:
-            terms = [t.strip() for t in title.split(",") if t.strip()]
-            if terms:
-                or_clauses = ["j.title ILIKE %s"] * len(terms)
-                conditions.append(f"({' OR '.join(or_clauses)})")
-                params.extend(f"%{t}%" for t in terms)
+            conditions.append(
+                "(to_tsvector('english', coalesce(j.title, '')) || "
+                "to_tsvector('english', coalesce(j.description_stripped, '')))"
+                " @@ websearch_to_tsquery('english', %s)"
+            )
+            params.append(title)
 
         if location:
             terms = [t.strip() for t in location.split(",") if t.strip()]

--- a/src/jobbuddy/store.py
+++ b/src/jobbuddy/store.py
@@ -505,11 +505,11 @@ class JobStore:
 
         if title:
             conditions.append(
-                "(to_tsvector('english', coalesce(j.title, '')) || "
-                "to_tsvector('english', coalesce(j.description_stripped, '')))"
-                " @@ websearch_to_tsquery('english', %s)"
+                "(to_tsvector('english', coalesce(j.title, '')) @@ websearch_to_tsquery('english', %s)"
+                " OR "
+                "to_tsvector('english', coalesce(j.description_stripped, '')) @@ websearch_to_tsquery('english', %s))"
             )
-            params.append(title)
+            params.extend([title, title])
 
         if location:
             terms = [t.strip() for t in location.split(",") if t.strip()]

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -179,10 +179,6 @@ class TestQueryFilters:
         rows = store.query_jobs(title="product manager")
         assert len(rows) == 2
 
-    def test_query_title_filter_comma_or(self, store):
-        rows = store.query_jobs(title="product manager,data scientist")
-        assert len(rows) == 3
-
     def test_query_location_filter(self, store):
         rows = store.query_jobs(location="seattle")
         assert len(rows) == 2
@@ -195,6 +191,63 @@ class TestQueryFilters:
     def test_query_limit(self, store):
         rows = store.query_jobs(limit=2)
         assert len(rows) == 2
+
+
+class TestFullTextSearch:
+    """Tests for PostgreSQL FTS replacing ILIKE title filter."""
+
+    @pytest.fixture(autouse=True)
+    def populate(self, store):
+        store.upsert_jobs("acme", [
+            make_job("1", "Software Engineer", "Seattle", description="Build backend services in Python."),
+            make_job("2", "Software Development Engineer", "Seattle", description="SDE role building distributed systems."),
+            make_job("3", "Senior Engineering Manager", "Remote", description="Lead a team of software engineers."),
+            make_job("4", "Product Manager", "Seattle", description="Drive product strategy for developer tools."),
+            make_job("5", "Data Scientist", "NYC", description="ML models for recommendation engine."),
+        ])
+        for jid in ["1", "2", "3", "4", "5"]:
+            store.conn.execute(
+                "UPDATE jobs SET description_stripped = description WHERE job_id = %s", (jid,)
+            )
+
+    def test_fts_stemming(self, store):
+        """'engineer' matches 'Engineering' and 'Engineers' via stemming."""
+        rows = store.query_jobs(title="engineer")
+        titles = {r["title"] for r in rows}
+        assert "Software Engineer" in titles
+        assert "Software Development Engineer" in titles
+        assert "Senior Engineering Manager" in titles
+
+    def test_fts_searches_description(self, store):
+        """FTS searches description_stripped, not just title."""
+        rows = store.query_jobs(title="python")
+        assert len(rows) >= 1
+        assert any(r["job_id"] == "1" for r in rows)
+
+    def test_fts_multi_word_query(self, store):
+        """Multi-word query matches jobs containing all terms."""
+        rows = store.query_jobs(title="software engineer")
+        titles = {r["title"] for r in rows}
+        assert "Software Engineer" in titles
+        assert "Software Development Engineer" in titles
+
+    def test_fts_websearch_or_syntax(self, store):
+        """websearch_to_tsquery OR syntax works."""
+        rows = store.query_jobs(title="engineer OR scientist")
+        titles = {r["title"] for r in rows}
+        assert "Software Engineer" in titles
+        assert "Data Scientist" in titles
+
+    def test_fts_no_match(self, store):
+        """FTS returns empty when no terms match."""
+        rows = store.query_jobs(title="blockchain")
+        assert len(rows) == 0
+
+    def test_location_still_ilike(self, store):
+        """Location filter still uses ILIKE substring matching."""
+        rows = store.query_jobs(location="seat")
+        assert len(rows) >= 1
+        assert all("Seattle" in (r["location"] or "") for r in rows)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #10

- **Replace ILIKE with FTS**: `_build_filter_conditions()` now uses `websearch_to_tsquery` across title + description_stripped instead of ILIKE on title only. Stemming handles morphological variants ("engineer" → "engineering", "engineers"), multi-field search catches jobs where the title is "SDE II" but the description says "software engineer".
- **Migration 008**: Per-field GIN indexes on `to_tsvector('english', title)` and `to_tsvector('english', description_stripped)` — weights tunable at query time without schema changes.
- **Comma-OR convention removed**: Was an LLM coping mechanism for ILIKE's lack of stemming. `websearch_to_tsquery` has native OR/quotes/negation syntax.
- **MCP + CLI descriptions rewritten**: Teach intent ("describe the kind of role") instead of mechanics ("comma-separated for OR, substring match").
- **Design principle added**: "The user is the human who installed the MCP server, not the LLM calling it" — top of AGENTS.md, framing all future work.

### Context

Observed the MCP client (Claude Desktop) in the wild: a human asked for "long tail Seattle SWE jobs" and the LLM had to enumerate 5 title variants, do two searches, and manually exclude 7 companies — ending up with 1 result. The tool was forcing the LLM into lossy translation between human intent and SQL parameters. See [issue comment](https://github.com/coryking/jobsearch-buddy/issues/10#issuecomment-4298819025) for details.

## Test plan

- [x] 6 new FTS tests: stemming, description search, multi-word, OR syntax, no-match, location-still-ILIKE
- [x] Existing filter tests pass (comma-OR test removed)
- [x] Full suite: 154 passed, 1 pre-existing flake (`test_diversity_round_robin_vector`)
- [ ] Run `jsb migrate` on prod to apply migration 008
- [ ] Verify MCP client behavior with natural role descriptions vs old synonym lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)