### PR TITLE
Add SmartRecruiters ATS fetcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,10 @@ the user.
 ## What This Project Is
 
 A command-line tool and MCP server for job searching: scrapes ATS job boards
-(Greenhouse, Ashby, Lever, Workday, Rippling, Paylocity, Workable, Eightfold,
-Oracle HCM), caches listings in PostgreSQL, and exposes them via a FastMCP server
-for use with Claude Desktop or any MCP-compatible client. Semantic search uses
-OpenAI-compatible embeddings with pgvector HNSW indexes.
+(see Supported ATS Platforms below), caches listings in PostgreSQL, and exposes
+them via a FastMCP server for use with Claude Desktop or any MCP-compatible
+client. Semantic search uses OpenAI-compatible embeddings with pgvector HNSW
+indexes.
 
 This is a practical tool, not enterprise software. Bias toward shipping.
 80% today beats 99% tomorrow.
@@ -53,22 +53,10 @@ src/jobbuddy/
 │   ├── enrich.py       # EnrichPhase — description enrichment for stub fetchers
 │   ├── strip.py        # StripPhase — LLM-based boilerplate removal (OpenAI-compatible)
 │   └── embed.py        # EmbedPhase — OpenAI-compatible batch embedding generation
-└── fetchers/           # Per-ATS-platform scrapers (strategy pattern)
+└── fetchers/           # Per-ATS scrapers — one file per platform (see Supported ATS Platforms)
     ├── base.py         # ATSFetcher ABC
-    ├── greenhouse.py
-    ├── ashby.py
-    ├── lever.py
-    ├── workday.py
-    ├── eightfold.py
-    ├── eightfold_v2.py
-    ├── oracle_hcm.py
-    ├── rippling.py
-    ├── paylocity.py
-    ├── phenom.py
-    ├── successfactors.py
-    ├── workable.py
-    ├── jibe.py
-    └── jobsync.py
+    ├── __init__.py     # Fetcher registry + factory
+    └── {platform}.py   # One module per ATS (greenhouse.py, workday.py, etc.)
 
 tests/
 ├── test_store.py       # JobStore: schema, upsert, embeddings, migrations
@@ -123,6 +111,7 @@ jsb embed-test [-f FILE...] [--stdin] [--json] QUERIES...   # Pure embedding sim
 | SuccessFactors | `{careers_domain}/job/{slug}/{id}/`                       |
 | Jibe        | `{careers_domain}/jobs/{id}` (iCIMS Attract layer)           |
 | JobSync     | `{careers_domain}/jobs/{slug}/{guid}` (Solr search layer)    |
+| SmartRecruiters | `jobs.smartrecruiters.com/{company}/{id}-{slug}`         |
 
 ## Configuration
 

--- a/src/jobbuddy/fetchers/__init__.py
+++ b/src/jobbuddy/fetchers/__init__.py
@@ -13,6 +13,7 @@ from jobbuddy.fetchers.oracle_hcm import OracleHCMFetcher
 from jobbuddy.fetchers.paylocity import PaylocityFetcher
 from jobbuddy.fetchers.phenom import PhenomFetcher
 from jobbuddy.fetchers.rippling import RipplingFetcher
+from jobbuddy.fetchers.smartrecruiters import SmartRecruitersFetcher
 from jobbuddy.fetchers.successfactors import SuccessFactorsFetcher
 from jobbuddy.fetchers.talentbrew import TalentBrewFetcher
 from jobbuddy.fetchers.workable import WorkableFetcher
@@ -32,6 +33,7 @@ _REGISTRY: dict[str, type[ATSFetcher]] = {
     "paylocity": PaylocityFetcher,
     "phenom": PhenomFetcher,
     "rippling": RipplingFetcher,
+    "smartrecruiters": SmartRecruitersFetcher,
     "successfactors": SuccessFactorsFetcher,
     "talentbrew": TalentBrewFetcher,
     "workable": WorkableFetcher,

--- a/src/jobbuddy/fetchers/smartrecruiters.py
+++ b/src/jobbuddy/fetchers/smartrecruiters.py
@@ -1,0 +1,180 @@
+"""SmartRecruiters ATS fetcher.
+
+Public API at api.smartrecruiters.com — no auth required. List endpoint
+returns metadata only (no descriptions), so this is a stub fetcher that
+needs enrichment to fetch individual job descriptions.
+
+Company registry fields:
+  - ats: "smartrecruiters"
+  - board: company identifier (e.g. "Wabtec", case-sensitive)
+  - country: optional ISO country code filter (e.g. "us")
+"""
+
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import date
+
+from jobbuddy.fetchers.base import ATSFetcher, JobList, ProgressCallback, RetryCallback
+from jobbuddy.models import Job, strip_html
+
+log = logging.getLogger(__name__)
+
+API_BASE = "https://api.smartrecruiters.com/v1/companies"
+PAGE_SIZE = 100
+
+
+def _parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+def _build_location(loc: dict) -> str:
+    if not loc:
+        return ""
+    full = loc.get("fullLocation", "")
+    if full:
+        return full
+    parts = [loc.get("city", ""), loc.get("region", ""), loc.get("country", "")]
+    return ", ".join(p for p in parts if p)
+
+
+def _extract_description(job_ad: dict) -> str | None:
+    sections = job_ad.get("sections", {})
+    parts = []
+    for key in ("jobDescription", "qualifications", "additionalInformation"):
+        section = sections.get(key, {})
+        html = section.get("text", "")
+        if html:
+            text = strip_html(html) if "<" in html else html.strip()
+            if text:
+                parts.append(text)
+    return "\n\n".join(parts) if parts else None
+
+
+class SmartRecruitersFetcher(ATSFetcher):
+    ats_type = "smartrecruiters"
+    descriptions_in_listing = False
+    enrich_delay = 0.0
+
+    def __init__(
+        self,
+        board: str,
+        name: str | None = None,
+        *,
+        country: str = "",
+    ):
+        super().__init__(board, name)
+        self.country = country
+
+    def _list_url(self) -> str:
+        return f"{API_BASE}/{self.board}/postings"
+
+    def _detail_url(self, posting_id: str) -> str:
+        return f"{API_BASE}/{self.board}/postings/{posting_id}"
+
+    def _list_params(self, offset: int) -> dict:
+        params: dict = {"offset": offset, "limit": PAGE_SIZE}
+        if self.country:
+            params["country"] = self.country
+        return params
+
+    def _posting_url(self, posting_id: str) -> str:
+        return f"https://jobs.smartrecruiters.com/{self.board}/{posting_id}"
+
+    def _parse_listing(self, data: dict) -> Job:
+        posting_id = str(data.get("id", ""))
+        loc = data.get("location", {})
+        dept = data.get("department", {})
+        return Job(
+            id=posting_id,
+            title=data.get("name", ""),
+            location=_build_location(loc),
+            url=self._posting_url(posting_id),
+            apply_url=self._posting_url(posting_id),
+            published_at=_parse_date(data.get("releasedDate")),
+            department=dept.get("label") if dept else None,
+        )
+
+    def list_jobs(
+        self,
+        *,
+        on_progress: ProgressCallback | None = None,
+        on_retry: RetryCallback | None = None,
+    ) -> JobList:
+        url = self._list_url()
+
+        def _fetch_page(offset: int):
+            resp = self.client.get(url, params=self._list_params(offset))
+            resp.raise_for_status()
+            return resp.json()
+
+        data = self._retry_request(lambda: _fetch_page(0), on_retry=on_retry)
+        total = data.get("totalFound", 0)
+        raw_jobs = data.get("content", [])
+        jobs: JobList = [self._parse_listing(j) for j in raw_jobs]
+
+        if on_progress:
+            on_progress(len(jobs), total)
+
+        remaining_offsets = list(range(PAGE_SIZE, total, PAGE_SIZE))
+        if not remaining_offsets:
+            return jobs
+
+        lock = threading.Lock()
+
+        def _fetch_remaining(offset: int) -> list[Job]:
+            def _do_fetch():
+                page_data = self.client.get(url, params=self._list_params(offset))
+                page_data.raise_for_status()
+                return [self._parse_listing(j) for j in page_data.json().get("content", [])]
+            return self._retry_request(_do_fetch, on_retry=on_retry)
+
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = {executor.submit(_fetch_remaining, off): off for off in remaining_offsets}
+            for future in as_completed(futures):
+                page_jobs = future.result()
+                with lock:
+                    jobs.extend(page_jobs)
+                    current = len(jobs)
+                if on_progress:
+                    on_progress(current, total)
+
+        return jobs
+
+    def _fetch_detail(self, posting_id: str) -> dict:
+        resp = self.client.get(self._detail_url(posting_id))
+        resp.raise_for_status()
+        return resp.json()
+
+    def fetch_job(self, job_id: str) -> Job:
+        data = self._fetch_detail(job_id)
+        if not data or not data.get("id"):
+            raise ValueError(f"Posting {job_id} not found on {self.board}.")
+
+        loc = data.get("location", {})
+        dept = data.get("department", {})
+        job_ad = data.get("jobAd", {})
+        pid = str(data["id"])
+
+        posting_url = data.get("postingUrl", self._posting_url(pid))
+        apply_url = data.get("applyUrl", posting_url)
+
+        return Job(
+            id=pid,
+            title=data.get("name", ""),
+            location=_build_location(loc),
+            url=posting_url,
+            apply_url=apply_url,
+            published_at=_parse_date(data.get("releasedDate")),
+            department=dept.get("label") if dept else None,
+            description=_extract_description(job_ad),
+        )
+
+    def fetch_description(self, job_id: str, metadata: dict | None = None) -> str | None:  # noqa: ARG002
+        data = self._fetch_detail(job_id)
+        return _extract_description(data.get("jobAd", {}))

--- a/src/jobbuddy/url.py
+++ b/src/jobbuddy/url.py
@@ -468,6 +468,22 @@ def _parse_jobsync(url: str) -> ParsedURL | None:
 
 
 # ---------------------------------------------------------------------------
+# SmartRecruiters
+# ---------------------------------------------------------------------------
+# https://jobs.smartrecruiters.com/{companyIdentifier}/{postingId}-{slug}
+
+def _parse_smartrecruiters(url: str) -> ParsedURL | None:
+    m = re.search(
+        r"jobs\.smartrecruiters\.com/([^/]+)/(\d+)",
+        url,
+        re.IGNORECASE,
+    )
+    if m:
+        return ParsedURL(ats="smartrecruiters", board=m.group(1), job_id=m.group(2))
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -487,6 +503,7 @@ _PARSERS = [
     _parse_successfactors,
     _parse_jibe,
     _parse_jobsync,
+    _parse_smartrecruiters,
 ]
 
 

--- a/tests/test_smartrecruiters.py
+++ b/tests/test_smartrecruiters.py
@@ -1,0 +1,459 @@
+"""Tests for SmartRecruiters ATS fetcher and URL parsing."""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+from jobbuddy.fetchers.smartrecruiters import SmartRecruitersFetcher
+from jobbuddy.url import parse_url
+
+
+# ---------------------------------------------------------------------------
+# Sample API responses
+# ---------------------------------------------------------------------------
+
+LISTING_PAGE_0 = {
+    "offset": 0,
+    "limit": 100,
+    "totalFound": 101,
+    "content": [
+        {
+            "id": "3743990012777007",
+            "name": "Designer, AI 3",
+            "uuid": "82d4783a-1234-5678-9abc-def012345678",
+            "refNumber": "R0108838",
+            "company": {"identifier": "Wabtec", "name": "Wabtec"},
+            "releasedDate": "2026-04-22T19:18:15.881Z",
+            "location": {
+                "city": "Pittsburgh",
+                "region": "PA",
+                "country": "us",
+                "remote": False,
+                "hybrid": False,
+                "fullLocation": "Pittsburgh, PA, United States",
+            },
+            "department": {"id": "868639", "label": "Software Development/Engineering"},
+            "function": {"id": "engineering", "label": "Engineering"},
+            "typeOfEmployment": {"id": "permanent", "label": "Full-time"},
+            "experienceLevel": {"id": "mid_senior_level", "label": "Mid-Senior Level"},
+        },
+        {
+            "id": "3743990012776976",
+            "name": "Supply Chain Coordinator",
+            "uuid": "4bfc598d-aaaa-bbbb-cccc-dddddddddddd",
+            "refNumber": "R0108405",
+            "company": {"identifier": "Wabtec", "name": "Wabtec"},
+            "releasedDate": "2026-03-15T10:00:00.000Z",
+            "location": {
+                "city": "State College",
+                "region": "PA",
+                "country": "us",
+                "remote": False,
+                "hybrid": False,
+                "fullLocation": "State College, PA, United States",
+            },
+            "department": {},
+            "function": {"id": "other", "label": "Other"},
+            "typeOfEmployment": {"id": "permanent", "label": "Full-time"},
+        },
+    ],
+}
+
+LISTING_PAGE_1 = {
+    "offset": 100,
+    "limit": 100,
+    "totalFound": 101,
+    "content": [
+        {
+            "id": "3743990012773442",
+            "name": "Senior Director, Transit Services Sales",
+            "uuid": "cccccccc-dddd-eeee-ffff-000000000000",
+            "refNumber": "R0107999",
+            "company": {"identifier": "Wabtec", "name": "Wabtec"},
+            "releasedDate": "2026-04-01T08:30:00.000Z",
+            "location": {
+                "city": "Philadelphia",
+                "region": "PA",
+                "country": "us",
+                "fullLocation": "Philadelphia, PA, United States",
+            },
+            "department": {"id": "123", "label": "Sales"},
+        },
+    ],
+}
+
+DETAIL_RESPONSE = {
+    "id": "3743990012777007",
+    "name": "Designer, AI 3",
+    "uuid": "82d4783a-1234-5678-9abc-def012345678",
+    "company": {"identifier": "Wabtec", "name": "Wabtec"},
+    "releasedDate": "2026-04-22T19:18:15.881Z",
+    "location": {
+        "city": "Pittsburgh",
+        "region": "PA",
+        "country": "us",
+        "fullLocation": "Pittsburgh, PA, United States",
+    },
+    "department": {"id": "868639", "label": "Software Development/Engineering"},
+    "postingUrl": "https://jobs.smartrecruiters.com/Wabtec/3743990012777007-designer-ai-3",
+    "applyUrl": "https://jobs.smartrecruiters.com/Wabtec/3743990012777007-designer-ai-3?oga=true",
+    "jobAd": {
+        "sections": {
+            "companyDescription": {
+                "title": "Company Description",
+                "text": "<p>Wabtec is a global company.</p>",
+            },
+            "jobDescription": {
+                "title": "Job Description",
+                "text": "<p>Design <b>AI systems</b> for rail.</p>",
+            },
+            "qualifications": {
+                "title": "Qualifications",
+                "text": "<p>BS in Computer Science required.</p>",
+            },
+            "additionalInformation": {
+                "title": "Additional Information",
+                "text": "<p>Salary range: $80,000-$120,000.</p>",
+            },
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_fetcher(**overrides) -> SmartRecruitersFetcher:
+    defaults = dict(board="Wabtec", name="Wabtec", country="us")
+    defaults.update(overrides)
+    board = defaults.pop("board")
+    name = defaults.pop("name")
+    f = SmartRecruitersFetcher(board, name, **defaults)
+    f.client = MagicMock()
+    f.backoff_base = 0.01
+    return f
+
+
+def mock_get_response(json_data, status_code=200):
+    resp = MagicMock()
+    resp.json.return_value = json_data
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# list_jobs tests
+# ---------------------------------------------------------------------------
+
+
+class TestSmartRecruitersListJobs:
+    def test_single_page(self):
+        """list_jobs parses a single-page response correctly."""
+        fetcher = make_fetcher()
+        single_page = {
+            "offset": 0,
+            "limit": 100,
+            "totalFound": 2,
+            "content": LISTING_PAGE_0["content"],
+        }
+        fetcher.client.get.return_value = mock_get_response(single_page)
+
+        jobs = fetcher.list_jobs()
+
+        assert len(jobs) == 2
+        assert jobs[0].id == "3743990012777007"
+        assert jobs[0].title == "Designer, AI 3"
+        assert jobs[0].location == "Pittsburgh, PA, United States"
+        assert jobs[0].department == "Software Development/Engineering"
+        assert jobs[0].published_at == date(2026, 4, 22)
+        assert jobs[0].url == "https://jobs.smartrecruiters.com/Wabtec/3743990012777007"
+        assert jobs[0].description is None
+
+    def test_pagination(self):
+        """list_jobs paginates through multiple pages."""
+        fetcher = make_fetcher()
+        fetcher.client.get.side_effect = [
+            mock_get_response(LISTING_PAGE_0),
+            mock_get_response(LISTING_PAGE_1),
+        ]
+
+        jobs = fetcher.list_jobs()
+
+        assert len(jobs) == 3
+        ids = {j.id for j in jobs}
+        assert ids == {"3743990012777007", "3743990012776976", "3743990012773442"}
+
+    def test_progress_callback(self):
+        """list_jobs calls on_progress with (fetched, total)."""
+        fetcher = make_fetcher()
+        single_page = {
+            "offset": 0, "limit": 100, "totalFound": 1,
+            "content": [LISTING_PAGE_0["content"][0]],
+        }
+        fetcher.client.get.return_value = mock_get_response(single_page)
+
+        progress = []
+        fetcher.list_jobs(on_progress=lambda f, t: progress.append((f, t)))
+        assert progress[-1] == (1, 1)
+
+    def test_empty_response(self):
+        """list_jobs handles zero results gracefully."""
+        fetcher = make_fetcher()
+        empty = {"offset": 0, "limit": 100, "totalFound": 0, "content": []}
+        fetcher.client.get.return_value = mock_get_response(empty)
+
+        jobs = fetcher.list_jobs()
+        assert jobs == []
+
+    def test_missing_released_date(self):
+        """Jobs with no releasedDate get published_at=None."""
+        fetcher = make_fetcher()
+        no_date = {
+            "offset": 0, "limit": 100, "totalFound": 1,
+            "content": [{
+                "id": "999",
+                "name": "Test Job",
+                "location": {"fullLocation": "Remote"},
+                "department": {},
+            }],
+        }
+        fetcher.client.get.return_value = mock_get_response(no_date)
+
+        jobs = fetcher.list_jobs()
+        assert jobs[0].published_at is None
+
+    def test_empty_department(self):
+        """Jobs with empty department dict get department=None."""
+        fetcher = make_fetcher()
+        single_page = {
+            "offset": 0, "limit": 100, "totalFound": 1,
+            "content": [LISTING_PAGE_0["content"][1]],
+        }
+        fetcher.client.get.return_value = mock_get_response(single_page)
+
+        jobs = fetcher.list_jobs()
+        assert jobs[0].department is None
+
+    def test_country_filter_passed(self):
+        """Country filter is included in API params."""
+        fetcher = make_fetcher(country="us")
+        single_page = {"offset": 0, "limit": 100, "totalFound": 0, "content": []}
+        fetcher.client.get.return_value = mock_get_response(single_page)
+
+        fetcher.list_jobs()
+
+        call_kwargs = fetcher.client.get.call_args
+        assert call_kwargs.kwargs["params"]["country"] == "us"
+
+    def test_no_country_filter(self):
+        """Without country config, no country param is sent."""
+        fetcher = make_fetcher(country="")
+        single_page = {"offset": 0, "limit": 100, "totalFound": 0, "content": []}
+        fetcher.client.get.return_value = mock_get_response(single_page)
+
+        fetcher.list_jobs()
+
+        call_kwargs = fetcher.client.get.call_args
+        assert "country" not in call_kwargs.kwargs["params"]
+
+    def test_location_fallback(self):
+        """When fullLocation is missing, location is built from parts."""
+        fetcher = make_fetcher()
+        no_full = {
+            "offset": 0, "limit": 100, "totalFound": 1,
+            "content": [{
+                "id": "111",
+                "name": "Test",
+                "location": {"city": "Seattle", "region": "WA", "country": "us"},
+                "department": {},
+            }],
+        }
+        fetcher.client.get.return_value = mock_get_response(no_full)
+
+        jobs = fetcher.list_jobs()
+        assert jobs[0].location == "Seattle, WA, us"
+
+    def test_missing_location(self):
+        """Jobs with no location dict get empty string."""
+        fetcher = make_fetcher()
+        no_loc = {
+            "offset": 0, "limit": 100, "totalFound": 1,
+            "content": [{
+                "id": "222",
+                "name": "Test",
+                "department": {},
+            }],
+        }
+        fetcher.client.get.return_value = mock_get_response(no_loc)
+
+        jobs = fetcher.list_jobs()
+        assert jobs[0].location == ""
+
+
+# ---------------------------------------------------------------------------
+# fetch_job tests
+# ---------------------------------------------------------------------------
+
+
+class TestSmartRecruitersFetchJob:
+    def test_fetch_job_detail(self):
+        """fetch_job retrieves full details from the detail API."""
+        fetcher = make_fetcher()
+        fetcher.client.get.return_value = mock_get_response(DETAIL_RESPONSE)
+
+        job = fetcher.fetch_job("3743990012777007")
+
+        assert job.id == "3743990012777007"
+        assert job.title == "Designer, AI 3"
+        assert job.location == "Pittsburgh, PA, United States"
+        assert job.department == "Software Development/Engineering"
+        assert job.published_at == date(2026, 4, 22)
+        assert job.url == "https://jobs.smartrecruiters.com/Wabtec/3743990012777007-designer-ai-3"
+        assert job.apply_url == "https://jobs.smartrecruiters.com/Wabtec/3743990012777007-designer-ai-3?oga=true"
+
+    def test_description_combines_sections(self):
+        """Description combines jobDescription + qualifications + additionalInformation (not companyDescription)."""
+        fetcher = make_fetcher()
+        fetcher.client.get.return_value = mock_get_response(DETAIL_RESPONSE)
+
+        job = fetcher.fetch_job("3743990012777007")
+
+        assert "AI systems" in job.description
+        assert "Computer Science" in job.description
+        assert "Salary range" in job.description
+        assert "global company" not in job.description
+
+    def test_description_strips_html(self):
+        """HTML tags are stripped from description sections."""
+        fetcher = make_fetcher()
+        fetcher.client.get.return_value = mock_get_response(DETAIL_RESPONSE)
+
+        job = fetcher.fetch_job("3743990012777007")
+
+        assert "<p>" not in job.description
+        assert "<b>" not in job.description
+
+    def test_fetch_job_no_description(self):
+        """fetch_job handles empty jobAd sections."""
+        fetcher = make_fetcher()
+        no_desc = {**DETAIL_RESPONSE, "jobAd": {"sections": {}}}
+        fetcher.client.get.return_value = mock_get_response(no_desc)
+
+        job = fetcher.fetch_job("3743990012777007")
+        assert job.description is None
+
+    def test_fetch_job_not_found(self):
+        """fetch_job raises ValueError when detail response is empty."""
+        fetcher = make_fetcher()
+        fetcher.client.get.return_value = mock_get_response({})
+
+        with pytest.raises(ValueError, match="not found"):
+            fetcher.fetch_job("NONEXISTENT")
+
+    def test_posting_url_fallback(self):
+        """When postingUrl is missing from detail, falls back to constructed URL."""
+        fetcher = make_fetcher()
+        no_url = {k: v for k, v in DETAIL_RESPONSE.items() if k not in ("postingUrl", "applyUrl")}
+        fetcher.client.get.return_value = mock_get_response(no_url)
+
+        job = fetcher.fetch_job("3743990012777007")
+        assert job.url == "https://jobs.smartrecruiters.com/Wabtec/3743990012777007"
+
+
+# ---------------------------------------------------------------------------
+# fetch_description tests
+# ---------------------------------------------------------------------------
+
+
+class TestSmartRecruitersFetchDescription:
+    def test_returns_stripped_description(self):
+        """fetch_description returns combined, HTML-stripped sections."""
+        fetcher = make_fetcher()
+        fetcher.client.get.return_value = mock_get_response(DETAIL_RESPONSE)
+
+        desc = fetcher.fetch_description("3743990012777007")
+
+        assert desc is not None
+        assert "AI systems" in desc
+        assert "Computer Science" in desc
+        assert "<p>" not in desc
+
+    def test_empty_sections(self):
+        """fetch_description returns None when sections are empty."""
+        fetcher = make_fetcher()
+        no_desc = {**DETAIL_RESPONSE, "jobAd": {"sections": {}}}
+        fetcher.client.get.return_value = mock_get_response(no_desc)
+
+        desc = fetcher.fetch_description("3743990012777007")
+        assert desc is None
+
+    def test_no_job_ad(self):
+        """fetch_description returns None when jobAd key is missing."""
+        fetcher = make_fetcher()
+        no_ad = {k: v for k, v in DETAIL_RESPONSE.items() if k != "jobAd"}
+        fetcher.client.get.return_value = mock_get_response(no_ad)
+
+        desc = fetcher.fetch_description("3743990012777007")
+        assert desc is None
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class TestSmartRecruitersConfig:
+    def test_descriptions_in_listing_is_false(self):
+        """SmartRecruiters is a stub fetcher — descriptions_in_listing = False."""
+        assert SmartRecruitersFetcher.descriptions_in_listing is False
+
+    def test_ats_type(self):
+        assert SmartRecruitersFetcher.ats_type == "smartrecruiters"
+
+    def test_api_urls(self):
+        fetcher = SmartRecruitersFetcher("Wabtec")
+        assert fetcher._list_url() == "https://api.smartrecruiters.com/v1/companies/Wabtec/postings"
+        assert fetcher._detail_url("123") == "https://api.smartrecruiters.com/v1/companies/Wabtec/postings/123"
+
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+
+class TestSmartRecruitersURLParsing:
+    def test_standard_posting_url(self):
+        result = parse_url("https://jobs.smartrecruiters.com/Wabtec/3743990012777007-designer-ai-3")
+        assert result is not None
+        assert result.ats == "smartrecruiters"
+        assert result.board == "Wabtec"
+        assert result.job_id == "3743990012777007"
+
+    def test_posting_url_with_query(self):
+        result = parse_url("https://jobs.smartrecruiters.com/Wabtec/3743990012777007-designer?oga=true")
+        assert result is not None
+        assert result.ats == "smartrecruiters"
+        assert result.board == "Wabtec"
+        assert result.job_id == "3743990012777007"
+
+    def test_different_company(self):
+        result = parse_url("https://jobs.smartrecruiters.com/Visa/744000122323342-sr-consultant")
+        assert result is not None
+        assert result.ats == "smartrecruiters"
+        assert result.board == "Visa"
+        assert result.job_id == "744000122323342"
+
+    def test_non_smartrecruiters_url(self):
+        result = parse_url("https://boards.greenhouse.io/acme/jobs/123")
+        assert result is not None
+        assert result.ats == "greenhouse"
+
+    def test_unrelated_url(self):
+        result = parse_url("https://example.com/jobs/123")
+        # Should not match smartrecruiters
+        if result is not None:
+            assert result.ats != "smartrecruiters"


### PR DESCRIPTION
## Summary
- Adds SmartRecruiters fetcher using the public API at `api.smartrecruiters.com/v1/companies/{id}/postings` (no auth required)
- Stub fetcher pattern (`descriptions_in_listing = False`) — list endpoint returns metadata only, descriptions fetched per-job via detail endpoint during enrichment
- Threaded pagination (100/page, 5 workers), optional `country` ISO code filtering
- URL parser for `jobs.smartrecruiters.com/{company}/{id}-{slug}` pattern
- Consolidates AGENTS.md — removes duplicated platform lists from intro paragraph and file tree; Supported ATS Platforms table is now the single source of truth

## Live-tested against Wabtec (274 US jobs)
- `list_jobs()` — paginated fetch, correct field mapping
- `fetch_job()` — full description from detail endpoint (jobDescription + qualifications + additionalInformation sections)
- `fetch_description()` — enrichment path
- URL parsing — board + job_id extraction from posting URLs

## Note on issue #17 companies
AbacusAI, Alkira, and Chronicle of Higher Ed all return 0 postings from the API — they appear to have left SmartRecruiters or have no public postings. Company registration deferred (DB migration in progress).

## Test plan
- [x] Existing test suite passes (3 pre-existing failures unrelated to this change)
- [x] Live API test: list_jobs with pagination against Wabtec
- [x] Live API test: fetch_job returns full description
- [x] Live API test: fetch_description enrichment path
- [x] URL parsing for SmartRecruiters posting URLs

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)