### PR TITLE
Vector-first hybrid search with query embedding cache

### DIFF
--- a/src/jobbuddy/migrations/010_query_embeddings_cache.sql
+++ b/src/jobbuddy/migrations/010_query_embeddings_cache.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS query_embeddings (
+    query_text TEXT PRIMARY KEY,
+    embedding  vector(1536) NOT NULL,
+    model      TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/src/jobbuddy/migrations/010_query_embeddings_cache.sql
+++ b/src/jobbuddy/migrations/010_query_embeddings_cache.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS query_embeddings (
-    query_text TEXT PRIMARY KEY,
-    embedding  vector(1536) NOT NULL,
+    query_text TEXT NOT NULL,
     model      TEXT NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    embedding  vector(1536) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (query_text, model)
 );

--- a/src/jobbuddy/search.py
+++ b/src/jobbuddy/search.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 
-from jobbuddy.embeddings import embed_query
 from jobbuddy.store import JobStore
 
 
@@ -28,10 +27,8 @@ class VectorSearch:
         limit: int = 25,
     ) -> list[SearchResult]:
         if query:
-            query_vec = embed_query(query)
             rows = self.store.hybrid_search(
                 query,
-                query_vec,
                 company=company,
                 exclude_companies=exclude_companies,
                 location=location,

--- a/src/jobbuddy/store.py
+++ b/src/jobbuddy/store.py
@@ -14,6 +14,7 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Json
 
 from jobbuddy.models import Company, Job
+from jobbuddy.settings import get_settings as _get_settings
 from jobbuddy.types import EmbedWorkItem, StripWorkItem
 
 log = logging.getLogger(__name__)
@@ -519,15 +520,28 @@ class JobStore:
     DIVERSITY_POOL_SIZE = 500
 
     RRF_K = 50
-    FTS_CANDIDATE_POOL = 200
-    FTS_POOL_SIZE = 60
-    VECTOR_POOL_SIZE = 60
-    FTS_WEIGHTS = "{0.1, 0.2, 0.1, 1.0}"
+    SEMANTIC_POOL_SIZE = 200
+
+    def _ensure_query_embedding(self, query_text: str) -> None:
+        """Guarantee query_text has an embedding row. Calls OpenAI on miss."""
+        from jobbuddy.embeddings import embed_query
+
+        model = _get_settings().embedding_model
+        row = self.conn.execute(
+            "SELECT 1 FROM query_embeddings WHERE query_text = %s AND model = %s",
+            (query_text, model),
+        ).fetchone()
+        if row:
+            return
+        vec = embed_query(query_text)
+        self.conn.execute(
+            "INSERT INTO query_embeddings (query_text, embedding, model) VALUES (%s, %s, %s) ON CONFLICT DO NOTHING",
+            (query_text, vec, model),
+        )
 
     def hybrid_search(
         self,
         query_text: str,
-        query_embedding: list[float],
         *,
         company: str | None = None,
         exclude_companies: list[str] | None = None,
@@ -535,54 +549,46 @@ class JobStore:
         posted_after: str | None = None,
         k: int = 25,
     ) -> list[dict]:
-        """Hybrid FTS + vector search with RRF fusion and round-robin diversity.
+        """Hybrid vector + FTS search with RRF fusion and round-robin diversity.
 
-        Runs FTS and vector search as parallel CTEs, merges via Reciprocal
-        Rank Fusion, then applies round-robin diversity across companies.
-        Gracefully degrades: if FTS matches zero rows, vector-only results
-        are returned; if no embeddings exist, FTS-only results are returned.
+        Vector search (HNSW) picks the top candidates, FTS provides a binary
+        keyword-match boost via RRF. The query embedding is joined from the
+        query_embeddings table — the vector never leaves the database.
         """
+        self._ensure_query_embedding(query_text)
+        settings = _get_settings()
         conditions, params = self._build_filter_conditions(
             company=company, exclude_companies=exclude_companies,
             location=location, posted_after=posted_after,
         )
         where = " AND ".join(conditions)
 
-        fts_params = params + [query_text, self.FTS_CANDIDATE_POOL, query_text, self.FTS_POOL_SIZE]
-        vec_params = [query_embedding] + params + [query_embedding, self.VECTOR_POOL_SIZE]
+        query_params = [query_text, settings.embedding_model]
+        vec_params = params + [self.SEMANTIC_POOL_SIZE]
+        fts_params = [query_text]
 
         sql = f"""
-            WITH fts_candidates AS (
-                SELECT j.id, j.fts_vector
-                FROM jobs j
-                WHERE {where}
-                  AND j.fts_vector @@ websearch_to_tsquery('english', %s)
-                LIMIT %s
-            ),
-            fts AS (
-                SELECT id,
-                       row_number() OVER (
-                           ORDER BY ts_rank_cd(
-                               '{self.FTS_WEIGHTS}'::float4[],
-                               fts_vector,
-                               websearch_to_tsquery('english', %s),
-                               32
-                           ) DESC
-                       ) AS rank_ix
-                FROM fts_candidates
-                ORDER BY rank_ix
-                LIMIT %s
+            WITH qvec AS (
+                SELECT embedding FROM query_embeddings
+                WHERE query_text = %s AND model = %s
             ),
             semantic AS (
                 SELECT e.job_id AS id,
                        row_number() OVER (
-                           ORDER BY e.embedding <=> %s::vector
+                           ORDER BY e.embedding <=> (SELECT embedding FROM qvec)
                        ) AS rank_ix
                 FROM job_embeddings e
                 JOIN jobs j ON e.job_id = j.id
                 WHERE {where}
-                ORDER BY e.embedding <=> %s::vector
+                ORDER BY e.embedding <=> (SELECT embedding FROM qvec)
                 LIMIT %s
+            ),
+            fts AS (
+                SELECT s.id,
+                       row_number() OVER () AS rank_ix
+                FROM semantic s
+                JOIN jobs j ON s.id = j.id
+                WHERE j.fts_vector @@ websearch_to_tsquery('english', %s)
             ),
             merged AS (
                 SELECT coalesce(f.id, s.id) AS id,
@@ -610,7 +616,7 @@ class JobStore:
             ORDER BY rn, rrf_score DESC
             LIMIT %s
         """
-        all_params = fts_params + vec_params + [k]
+        all_params = query_params + vec_params + fts_params + [k]
 
         rows = self.conn.execute(sql, all_params).fetchall()
         internal_cols = {"rn", "rank_ix"}

--- a/src/jobbuddy/store.py
+++ b/src/jobbuddy/store.py
@@ -521,6 +521,7 @@ class JobStore:
 
     RRF_K = 50
     SEMANTIC_POOL_SIZE = 200
+    FTS_BOOST = 0.015
 
     def _ensure_query_embedding(self, query_text: str) -> None:
         """Guarantee query_text has an embedding row. Calls OpenAI on miss."""
@@ -583,19 +584,19 @@ class JobStore:
                 ORDER BY e.embedding <=> (SELECT embedding FROM qvec)
                 LIMIT %s
             ),
-            fts AS (
-                SELECT s.id,
-                       row_number() OVER () AS rank_ix
+            fts_matches AS (
+                SELECT s.id
                 FROM semantic s
                 JOIN jobs j ON s.id = j.id
                 WHERE j.fts_vector @@ websearch_to_tsquery('english', %s)
             ),
             merged AS (
-                SELECT coalesce(f.id, s.id) AS id,
-                       coalesce(1.0 / ({self.RRF_K} + f.rank_ix), 0.0)
-                     + coalesce(1.0 / ({self.RRF_K} + s.rank_ix), 0.0) AS rrf_score
-                FROM fts f
-                FULL OUTER JOIN semantic s ON f.id = s.id
+                SELECT s.id,
+                       1.0 / ({self.RRF_K} + s.rank_ix)
+                     + CASE WHEN f.id IS NOT NULL THEN {self.FTS_BOOST} ELSE 0.0 END
+                       AS rrf_score
+                FROM semantic s
+                LEFT JOIN fts_matches f ON s.id = f.id
             ),
             scored AS (
                 SELECT j.*, ss.last_sync, c.name AS company_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ def ensure_pg_schema():
 def clean_test_data():
     """Clean child tables between tests. Companies persist from session setup."""
     conn = psycopg.connect(TEST_CONNINFO, autocommit=True)
+    conn.execute("DELETE FROM query_embeddings")
     conn.execute("DELETE FROM job_embeddings")
     conn.execute("DELETE FROM jobs")
     conn.execute("DELETE FROM sync_status")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -66,7 +66,7 @@ class TestVectorSearch:
     def test_search_returns_results(self, vs):
         """Search returns ranked SearchResult objects."""
         query_vec = _fake_vec(DIMS, seed=1).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = vs.search(query="AI product strategy")
         assert len(results) > 0
         assert isinstance(results[0], SearchResult)
@@ -75,14 +75,14 @@ class TestVectorSearch:
 
     def test_search_respects_limit(self, vs):
         query_vec = _fake_vec(DIMS, seed=1).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = vs.search(query="anything", limit=1)
         assert len(results) == 1
 
     def test_search_ranked_by_similarity(self, vs):
         """Results are sorted by descending similarity."""
         query_vec = _fake_vec(DIMS, seed=1).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = vs.search(query="anything", limit=3)
         scores = [r.score for r in results]
         assert scores == sorted(scores, reverse=True)
@@ -91,7 +91,7 @@ class TestVectorSearch:
         """Removed jobs don't appear in results."""
         vs.store.upsert_jobs("acme", [])
         query_vec = _fake_vec(DIMS, seed=1).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = vs.search(query="anything")
         assert len(results) == 0
 
@@ -99,7 +99,7 @@ class TestVectorSearch:
         """Search with no embeddings returns empty."""
         search = VectorSearch(pg_conninfo)
         query_vec = _fake_vec(DIMS, seed=0).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = search.search(query="anything")
         assert results == []
         search.close()
@@ -166,7 +166,7 @@ class TestSearchDiversity:
     def test_diversity_round_robin_vector(self, multi_company_vs):
         """Vector search distributes results across companies, not dominated by acme."""
         query_vec = _fake_vec(DIMS, seed=100).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = multi_company_vs.search(query="engineering", limit=15)
         companies = [r.job["company_slug"] for r in results]
         assert "acme" in companies
@@ -177,7 +177,7 @@ class TestSearchDiversity:
     def test_exclude_companies_vector(self, multi_company_vs):
         """Excluded companies don't appear in vector search results."""
         query_vec = _fake_vec(DIMS, seed=100).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = multi_company_vs.search(
                 query="engineering", exclude_companies=["acme"], limit=15
             )
@@ -188,7 +188,7 @@ class TestSearchDiversity:
     def test_no_rn_in_results(self, multi_company_vs):
         """The internal rn column doesn't leak into result dicts."""
         query_vec = _fake_vec(DIMS, seed=100).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = multi_company_vs.search(query="engineering", limit=5)
         for r in results:
             assert "rn" not in r.job
@@ -200,7 +200,7 @@ class TestHybridSearch:
     def test_hybrid_boosts_keyword_match(self, vs):
         """A query matching FTS + vector returns the right job ranked first."""
         query_vec = _fake_vec(DIMS, seed=1).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = vs.search(query="AI product manager")
         assert len(results) > 0
         assert results[0].score is not None
@@ -209,7 +209,7 @@ class TestHybridSearch:
     def test_hybrid_vector_only_fallback(self, vs):
         """When FTS matches zero rows, vector search still returns results."""
         query_vec = _fake_vec(DIMS, seed=2).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = vs.search(query="xyzzy nonexistent gibberish")
         assert len(results) > 0
         assert all(r.score is not None for r in results)
@@ -235,7 +235,7 @@ class TestHybridSearch:
         vs.store.store_embedding(row["id"], str(row["content_hash"]), company_hash, vec)
 
         query_vec = _fake_vec(DIMS, seed=1).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = vs.search(query="AI engineer", company="beta")
         assert len(results) == 1
         assert results[0].job["company_slug"] == "beta"
@@ -243,7 +243,7 @@ class TestHybridSearch:
     def test_hybrid_with_location_filter(self, vs):
         """Location filter works with hybrid search."""
         query_vec = _fake_vec(DIMS, seed=1).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = vs.search(query="product", location="Seattle")
         for r in results:
             assert "Seattle" in r.job["location"]
@@ -251,7 +251,7 @@ class TestHybridSearch:
     def test_hybrid_with_exclude_companies(self, vs):
         """Excluded companies don't appear in hybrid results."""
         query_vec = _fake_vec(DIMS, seed=1).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = vs.search(query="engineer", exclude_companies=["acme"])
         for r in results:
             assert r.job["company_slug"] != "acme"
@@ -259,7 +259,7 @@ class TestHybridSearch:
     def test_hybrid_no_rn_in_results(self, vs):
         """Internal ranking columns don't leak into result dicts."""
         query_vec = _fake_vec(DIMS, seed=1).tolist()
-        with patch("jobbuddy.search.embed_query", return_value=query_vec):
+        with patch("jobbuddy.embeddings.embed_query", return_value=query_vec):
             results = vs.search(query="engineer", limit=3)
         for r in results:
             assert "rn" not in r.job


### PR DESCRIPTION
## Summary

- Restructure hybrid search: vector search (HNSW) picks candidates first, FTS re-ranks as a binary keyword boost — instead of two independent search legs merged with RRF
- Cache query embeddings in a new `query_embeddings` table, joined server-side so the 6KB vector never crosses the wire as a query parameter
- The store owns the ensure-then-query lifecycle — callers just pass query text

## Problem

The FTS leg scanned 25K+ rows via GIN bitmap heap scan, then scored each with `ts_rank_cd`, requiring heap reads of the `fts_vector` column from 7,500+ scattered pages. On the Azure burstable tier (B1ms, 120 IOPS P4 storage), this took 85s cold / 131s warm for broad queries like "software engineer."

## What changed

**Query shape** (the big win):
- Old: FTS finds 25K matches → scores all → takes 60 best. Vector finds 60. FULL OUTER JOIN merges.
- New: Vector finds 200 nearest neighbors (HNSW, fast). FTS checks which of those 200 match keywords (boolean `@@`, instant). RRF merges.
- `ts_rank_cd` removed entirely — scoring 200 rows from a random pre-limit sample was ranking noise anyway

**Performance on Azure burstable (B1ms, 120 IOPS)**:

| Version | Cold cache | Warm cache |
|---------|-----------|------------|
| Old (pre-limit hack) | ~2s | — |
| Old (full FTS scan) | 85s | 131s |
| **New (vector-first)** | **672ms** | **5.6ms** |

**Query embedding cache**:
- New `query_embeddings` table (migration 010) stores `(query_text, embedding, model)`
- `hybrid_search` joins against this table via a `qvec` CTE instead of receiving the vector as a parameter
- `_ensure_query_embedding()` handles the check-or-compute lifecycle internally
- Saves ~200-500ms API call + 6KB wire transfer on repeat queries

## Test plan

- [ ] All 16 search tests pass (vector, diversity, hybrid, filters)
- [ ] Run `jsb migrate` on prod to create `query_embeddings` table
- [ ] Test a search via MCP/CLI to verify cache miss → API call → cache hit flow
- [ ] Verify broad queries ("software engineer") return results in <1s
- [ ] Verify narrow queries ("robotics firmware") still work correctly

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)