### PR TITLE
Add Apple careers fetcher

### DIFF
--- a/src/jobbuddy/fetchers/__init__.py
+++ b/src/jobbuddy/fetchers/__init__.py
@@ -1,5 +1,6 @@
 """ATS fetcher registry and factory."""
 
+from jobbuddy.fetchers.apple import AppleFetcher
 from jobbuddy.fetchers.ashby import AshbyFetcher
 from jobbuddy.fetchers.avature import AvatureFetcher
 from jobbuddy.fetchers.base import ATSFetcher
@@ -21,6 +22,7 @@ from jobbuddy.fetchers.workday import WorkdayFetcher
 from jobbuddy.models import Company
 
 _REGISTRY: dict[str, type[ATSFetcher]] = {
+    "apple": AppleFetcher,
     "ashby": AshbyFetcher,
     "avature": AvatureFetcher,
     "eightfold": EightfoldFetcher,

--- a/src/jobbuddy/fetchers/apple.py
+++ b/src/jobbuddy/fetchers/apple.py
@@ -1,0 +1,176 @@
+"""Apple careers fetcher (jobs.apple.com)."""
+
+import json
+import logging
+import re
+
+from jobbuddy.fetchers.base import ATSFetcher, JobList, ProgressCallback, RetryCallback
+from jobbuddy.models import Job, strip_html
+
+log = logging.getLogger(__name__)
+
+PAGE_SIZE = 20  # Apple returns 20 results per SSR page
+
+
+def build_location(loc: dict) -> str:
+    """Build a location string from Apple's location object.
+
+    Level 2+ locations have city/state/country. Level 1 is country-only.
+    """
+    parts = [p for p in [loc.get("city"), loc.get("stateProvince"), loc.get("countryName")] if p]
+    return ", ".join(parts) if parts else loc.get("name", "")
+
+
+def parse_ssr_html(html: str) -> tuple[list[dict], int]:
+    """Extract search results and total count from Apple SSR hydration data.
+
+    Returns (search_results, total_records).
+    Raises ValueError if hydration data not found.
+    """
+    match = re.search(
+        r'window\.__staticRouterHydrationData = JSON\.parse\("(.+?)"\);',
+        html,
+    )
+    if not match:
+        raise ValueError("Could not find hydration data in Apple careers HTML")
+
+    raw = match.group(1)
+    unescaped = raw.encode().decode("unicode_escape")
+    data = json.loads(unescaped)
+
+    search_data = data["loaderData"]["search"]
+    results = search_data["searchResults"]
+    total = search_data["totalRecords"]
+    return results, total
+
+
+class AppleFetcher(ATSFetcher):
+    ats_type = "apple"
+    descriptions_in_listing = False
+    enrich_delay = 0.2
+
+    def _result_to_job(self, result: dict) -> Job:
+        """Map an SSR search result to a Job."""
+        position_id = result["positionId"]
+        slug = result.get("transformedPostingTitle", "")
+        locations = result.get("locations") or []
+        location_str = " | ".join(build_location(loc) for loc in locations)
+
+        team_obj = result.get("team") or {}
+        team_name = team_obj.get("teamName")
+
+        post_date = result.get("postDateInGMT", "")
+        published_at = post_date[:10] if post_date else None
+
+        url = f"https://jobs.apple.com/en-us/details/{position_id}/{slug}"
+
+        return Job(
+            id=position_id,
+            title=result.get("postingTitle", ""),
+            location=location_str,
+            url=url,
+            apply_url=url,
+            published_at=published_at,
+            department=team_name,
+            team=team_name,
+            description=result.get("jobSummary"),
+        )
+
+    def _fetch_ssr_page(self, page: int, *, on_retry: RetryCallback | None = None) -> tuple[list[dict], int]:
+        """Fetch a single SSR page and return (results, total)."""
+        def do_fetch():
+            resp = self.client.get(
+                f"https://jobs.apple.com/en-us/search?sort=newest&page={page}",
+            )
+            resp.raise_for_status()
+            return parse_ssr_html(resp.text)
+
+        return self._retry_request(do_fetch, on_retry=on_retry)
+
+    def list_jobs(
+        self,
+        *,
+        on_progress: ProgressCallback | None = None,
+        on_retry: RetryCallback | None = None,
+    ) -> JobList:
+        # Fetch page 1
+        results, total = self._fetch_ssr_page(1, on_retry=on_retry)
+        jobs: JobList = [self._result_to_job(r) for r in results]
+        if on_progress:
+            on_progress(len(jobs), total)
+
+        # Paginate remaining pages
+        total_pages = (total + PAGE_SIZE - 1) // PAGE_SIZE
+        for page in range(2, total_pages + 1):
+            page_results, _ = self._fetch_ssr_page(page, on_retry=on_retry)
+            jobs.extend(self._result_to_job(r) for r in page_results)
+            if on_progress:
+                on_progress(len(jobs), total)
+
+        return jobs
+
+    def _fetch_detail(self, job_id: str) -> dict:
+        """Fetch job detail from the Apple API."""
+        resp = self.client.get(
+            f"https://jobs.apple.com/api/v1/jobDetails/{job_id}",
+            params={"locale": "en-us"},
+            headers={"content-type": "application/json", "locale": "en-us"},
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        return body.get("res", body)
+
+    def _detail_to_job(self, data: dict) -> Job:
+        """Map a detail API response to a Job."""
+        position_id = data.get("jobNumber") or data["positionId"]
+        slug = data.get("transformedPostingTitle", "")
+        locations = data.get("locations") or []
+        location_str = " | ".join(build_location(loc) for loc in locations)
+
+        team_names = data.get("teamNames") or []
+        team_name = team_names[0] if team_names else None
+
+        post_date = data.get("postDateInGMT", "")
+        published_at = post_date[:10] if post_date else None
+
+        url = f"https://jobs.apple.com/en-us/details/{position_id}/{slug}"
+
+        # Combine summary + full description
+        summary = data.get("jobSummary", "")
+        raw_desc = data.get("description", "")
+        desc_text = strip_html(raw_desc) if raw_desc else ""
+
+        description = None
+        if summary and desc_text:
+            description = f"{summary}\n\n{desc_text}"
+        elif summary:
+            description = summary
+        elif desc_text:
+            description = desc_text
+
+        return Job(
+            id=position_id,
+            title=data.get("postingTitle", ""),
+            location=location_str,
+            url=url,
+            apply_url=url,
+            published_at=published_at,
+            department=team_name,
+            team=team_name,
+            description=description,
+        )
+
+    def fetch_job(self, job_id: str) -> Job:
+        data = self._fetch_detail(job_id)
+        return self._detail_to_job(data)
+
+    def fetch_description(self, job_id: str, metadata: dict | None = None) -> str | None:
+        """Fetch description directly from detail API without building a full Job."""
+        data = self._fetch_detail(job_id)
+        summary = data.get("jobSummary", "")
+        raw_desc = data.get("description", "")
+        desc_text = strip_html(raw_desc) if raw_desc else ""
+
+        if summary and desc_text:
+            return f"{summary}\n\n{desc_text}"
+        return summary or desc_text or None

--- a/src/jobbuddy/fetchers/apple.py
+++ b/src/jobbuddy/fetchers/apple.py
@@ -44,6 +44,17 @@ def parse_ssr_html(html: str) -> tuple[list[dict], int]:
     return results, total
 
 
+def build_description(data: dict) -> str | None:
+    """Combine jobSummary + description from a detail API response."""
+    summary = data.get("jobSummary", "")
+    raw_desc = data.get("description", "")
+    desc_text = strip_html(raw_desc) if raw_desc else ""
+
+    if summary and desc_text:
+        return f"{summary}\n\n{desc_text}"
+    return summary or desc_text or None
+
+
 class AppleFetcher(ATSFetcher):
     ats_type = "apple"
     descriptions_in_listing = False
@@ -114,7 +125,7 @@ class AppleFetcher(ATSFetcher):
         resp = self.client.get(
             f"https://jobs.apple.com/api/v1/jobDetails/{job_id}",
             params={"locale": "en-us"},
-            headers={"content-type": "application/json", "locale": "en-us"},
+            headers={"locale": "en-us"},
         )
         resp.raise_for_status()
         body = resp.json()
@@ -135,19 +146,6 @@ class AppleFetcher(ATSFetcher):
 
         url = f"https://jobs.apple.com/en-us/details/{position_id}/{slug}"
 
-        # Combine summary + full description
-        summary = data.get("jobSummary", "")
-        raw_desc = data.get("description", "")
-        desc_text = strip_html(raw_desc) if raw_desc else ""
-
-        description = None
-        if summary and desc_text:
-            description = f"{summary}\n\n{desc_text}"
-        elif summary:
-            description = summary
-        elif desc_text:
-            description = desc_text
-
         return Job(
             id=position_id,
             title=data.get("postingTitle", ""),
@@ -157,7 +155,7 @@ class AppleFetcher(ATSFetcher):
             published_at=published_at,
             department=team_name,
             team=team_name,
-            description=description,
+            description=build_description(data),
         )
 
     def fetch_job(self, job_id: str) -> Job:
@@ -166,11 +164,4 @@ class AppleFetcher(ATSFetcher):
 
     def fetch_description(self, job_id: str, metadata: dict | None = None) -> str | None:
         """Fetch description directly from detail API without building a full Job."""
-        data = self._fetch_detail(job_id)
-        summary = data.get("jobSummary", "")
-        raw_desc = data.get("description", "")
-        desc_text = strip_html(raw_desc) if raw_desc else ""
-
-        if summary and desc_text:
-            return f"{summary}\n\n{desc_text}"
-        return summary or desc_text or None
+        return build_description(self._fetch_detail(job_id))

--- a/src/jobbuddy/url.py
+++ b/src/jobbuddy/url.py
@@ -468,6 +468,23 @@ def _parse_jobsync(url: str) -> ParsedURL | None:
 
 
 # ---------------------------------------------------------------------------
+# Apple
+# ---------------------------------------------------------------------------
+# https://jobs.apple.com/en-us/details/{positionId}/{slug}
+# https://jobs.apple.com/{locale}/details/{positionId}/{slug}
+
+def _parse_apple(url: str) -> ParsedURL | None:
+    m = re.search(
+        r"jobs\.apple\.com/[^/]+/details/([^/]+)",
+        url,
+        re.IGNORECASE,
+    )
+    if m:
+        return ParsedURL(ats="apple", board="apple", job_id=m.group(1))
+    return None
+
+
+# ---------------------------------------------------------------------------
 # SmartRecruiters
 # ---------------------------------------------------------------------------
 # https://jobs.smartrecruiters.com/{companyIdentifier}/{postingId}-{slug}
@@ -504,6 +521,7 @@ _PARSERS = [
     _parse_jibe,
     _parse_jobsync,
     _parse_smartrecruiters,
+    _parse_apple,
 ]
 
 

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from jobbuddy.fetchers.apple import AppleFetcher, parse_ssr_html, build_location
+from jobbuddy.fetchers.apple import AppleFetcher, parse_ssr_html, build_location, build_description
 from jobbuddy.url import ParsedURL, parse_url
 
 
@@ -285,8 +285,32 @@ class TestFetchJob:
         fetcher.fetch_job("200660378-0157")
 
         call_kwargs = fetcher.client.get.call_args
-        assert call_kwargs[1]["headers"]["content-type"] == "application/json"
         assert call_kwargs[1]["headers"]["locale"] == "en-us"
+        assert "content-type" not in call_kwargs[1]["headers"]
+
+
+# ---------------------------------------------------------------------------
+# build_description tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDescription:
+    def test_summary_and_description(self):
+        result = build_description(SAMPLE_JOB_DETAIL)
+        assert result.startswith("Imagine what you could do here")
+        assert "full job description" in result
+        assert "<p>" not in result
+
+    def test_summary_only(self):
+        data = {"jobSummary": "Just a summary", "description": ""}
+        assert build_description(data) == "Just a summary"
+
+    def test_description_only(self):
+        data = {"jobSummary": "", "description": "Raw desc"}
+        assert build_description(data) == "Raw desc"
+
+    def test_empty_returns_none(self):
+        assert build_description({}) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -1,0 +1,337 @@
+"""Tests for Apple careers fetcher and URL parser."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from jobbuddy.fetchers.apple import AppleFetcher, parse_ssr_html, build_location
+from jobbuddy.url import ParsedURL, parse_url
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_SEARCH_RESULT = {
+    "positionId": "200660378-0157",
+    "postingTitle": "Manufacturing Design Program Manager (MDPM)",
+    "transformedPostingTitle": "manufacturing-design-program-manager-mdpm",
+    "jobSummary": "Imagine what you could do here. At Apple...",
+    "locations": [
+        {
+            "postLocationId": "postLocation-AST",
+            "city": "Austin",
+            "stateProvince": "Texas",
+            "countryName": "United States",
+            "name": "Austin",
+            "level": 2,
+        }
+    ],
+    "team": {
+        "teamName": "Operations and Supply Chain",
+        "teamID": "teamsAndSubTeams-OPMFG",
+        "teamCode": "OPMFG",
+    },
+    "postDateInGMT": "2026-04-20T08:00:00.000Z",
+    "homeOffice": False,
+}
+
+SAMPLE_SEARCH_RESULT_MULTI_LOCATION = {
+    "positionId": "200700001",
+    "postingTitle": "Software Engineer",
+    "transformedPostingTitle": "software-engineer",
+    "jobSummary": "Join the team...",
+    "locations": [
+        {
+            "postLocationId": "postLocation-CUP",
+            "city": "Cupertino",
+            "stateProvince": "California",
+            "countryName": "United States",
+            "name": "Cupertino",
+            "level": 2,
+        },
+        {
+            "postLocationId": "postLocation-SFO",
+            "city": "San Francisco",
+            "stateProvince": "California",
+            "countryName": "United States",
+            "name": "San Francisco",
+            "level": 2,
+        },
+    ],
+    "team": {"teamName": "Software Engineering", "teamID": "t-SWE", "teamCode": "SWE"},
+    "postDateInGMT": "2026-04-15T12:00:00.000Z",
+    "homeOffice": False,
+}
+
+SAMPLE_SEARCH_RESULT_COUNTRY_ONLY = {
+    "positionId": "200700002",
+    "postingTitle": "Remote Analyst",
+    "transformedPostingTitle": "remote-analyst",
+    "jobSummary": "Work from anywhere...",
+    "locations": [
+        {
+            "postLocationId": "postLocation-US",
+            "city": "",
+            "stateProvince": "",
+            "countryName": "United States",
+            "name": "United States",
+            "level": 1,
+        },
+    ],
+    "team": {"teamName": "Data", "teamID": "t-DATA", "teamCode": "DATA"},
+    "postDateInGMT": "2026-04-10T00:00:00.000Z",
+    "homeOffice": True,
+}
+
+SAMPLE_JOB_DETAIL = {
+    "positionId": "200660378",
+    "jobNumber": "200660378-0157",
+    "postingTitle": "Manufacturing Design Program Manager (MDPM)",
+    "transformedPostingTitle": "manufacturing-design-program-manager-mdpm",
+    "jobSummary": "Imagine what you could do here. At Apple...",
+    "description": "<p>This is the <b>full job description</b> with HTML.</p>",
+    "locations": [
+        {
+            "city": "Austin",
+            "stateProvince": "Texas",
+            "countryName": "United States",
+            "name": "Austin",
+            "level": 2,
+        }
+    ],
+    "teamNames": ["Operations and Supply Chain"],
+    "postDateInGMT": "2026-04-20T08:00:00.000Z",
+}
+
+
+def make_ssr_html(search_results: list[dict], total_records: int) -> str:
+    """Build fake Apple SSR HTML with hydration data."""
+    loader_data = {
+        "search": {
+            "searchResults": search_results,
+            "totalRecords": total_records,
+        }
+    }
+    hydration = {
+        "loaderData": {"search": loader_data["search"]},
+    }
+    # Double-encode: JSON.parse("...") in the page
+    inner_json = json.dumps(hydration)
+    # Escape for embedding inside a JS string literal
+    escaped = inner_json.replace("\\", "\\\\").replace('"', '\\"')
+    return f"""
+    <html><head><script>
+    window.__staticRouterHydrationData = JSON.parse("{escaped}");
+    </script></head><body></body></html>
+    """
+
+
+# ---------------------------------------------------------------------------
+# SSR parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestSSRParsing:
+    def test_parse_ssr_html_single_result(self):
+        html = make_ssr_html([SAMPLE_SEARCH_RESULT], 1)
+        results, total = parse_ssr_html(html)
+        assert total == 1
+        assert len(results) == 1
+        assert results[0]["positionId"] == "200660378-0157"
+
+    def test_parse_ssr_html_multiple_results(self):
+        html = make_ssr_html(
+            [SAMPLE_SEARCH_RESULT, SAMPLE_SEARCH_RESULT_MULTI_LOCATION], 2
+        )
+        results, total = parse_ssr_html(html)
+        assert total == 2
+        assert len(results) == 2
+
+    def test_parse_ssr_html_no_match_raises(self):
+        with pytest.raises(ValueError, match="hydration"):
+            parse_ssr_html("<html><body>no data</body></html>")
+
+
+# ---------------------------------------------------------------------------
+# Location building tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLocation:
+    def test_city_state_country(self):
+        loc = SAMPLE_SEARCH_RESULT["locations"][0]
+        assert build_location(loc) == "Austin, Texas, United States"
+
+    def test_country_only(self):
+        loc = SAMPLE_SEARCH_RESULT_COUNTRY_ONLY["locations"][0]
+        assert build_location(loc) == "United States"
+
+    def test_multiple_locations_joined(self):
+        locs = SAMPLE_SEARCH_RESULT_MULTI_LOCATION["locations"]
+        result = " | ".join(build_location(loc) for loc in locs)
+        assert "Cupertino" in result
+        assert "San Francisco" in result
+
+
+# ---------------------------------------------------------------------------
+# list_jobs tests
+# ---------------------------------------------------------------------------
+
+
+class TestListJobs:
+    def test_single_page(self):
+        fetcher = AppleFetcher("apple")
+        html = make_ssr_html([SAMPLE_SEARCH_RESULT], 1)
+        mock_response = MagicMock()
+        mock_response.text = html
+        mock_response.raise_for_status = MagicMock()
+        fetcher.client = MagicMock()
+        fetcher.client.get.return_value = mock_response
+
+        jobs = fetcher.list_jobs()
+        assert len(jobs) == 1
+        job = jobs[0]
+        assert job.id == "200660378-0157"
+        assert job.title == "Manufacturing Design Program Manager (MDPM)"
+        assert "Austin" in job.location
+        assert job.url == "https://jobs.apple.com/en-us/details/200660378-0157/manufacturing-design-program-manager-mdpm"
+        assert job.department == "Operations and Supply Chain"
+        assert job.description == "Imagine what you could do here. At Apple..."
+        assert str(job.published_at) == "2026-04-20"
+
+    def test_pagination(self):
+        """Fetches multiple pages when totalRecords > 20."""
+        fetcher = AppleFetcher("apple")
+
+        # Page 1: 20 results, total 25
+        page1_results = [
+            {**SAMPLE_SEARCH_RESULT, "positionId": f"id-{i}", "transformedPostingTitle": f"job-{i}"}
+            for i in range(20)
+        ]
+        page1_html = make_ssr_html(page1_results, 25)
+
+        # Page 2: 5 results
+        page2_results = [
+            {**SAMPLE_SEARCH_RESULT, "positionId": f"id-{i}", "transformedPostingTitle": f"job-{i}"}
+            for i in range(20, 25)
+        ]
+        page2_html = make_ssr_html(page2_results, 25)
+
+        responses = []
+        for html in [page1_html, page2_html]:
+            resp = MagicMock()
+            resp.text = html
+            resp.raise_for_status = MagicMock()
+            responses.append(resp)
+
+        fetcher.client = MagicMock()
+        fetcher.client.get.side_effect = responses
+
+        progress_calls = []
+        jobs = fetcher.list_jobs(on_progress=lambda f, t: progress_calls.append((f, t)))
+        assert len(jobs) == 25
+        assert progress_calls[-1] == (25, 25)
+
+    def test_progress_callback(self):
+        fetcher = AppleFetcher("apple")
+        html = make_ssr_html([SAMPLE_SEARCH_RESULT], 1)
+        mock_response = MagicMock()
+        mock_response.text = html
+        mock_response.raise_for_status = MagicMock()
+        fetcher.client = MagicMock()
+        fetcher.client.get.return_value = mock_response
+
+        progress = []
+        fetcher.list_jobs(on_progress=lambda f, t: progress.append((f, t)))
+        assert progress == [(1, 1)]
+
+
+# ---------------------------------------------------------------------------
+# fetch_job tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchJob:
+    def test_fetch_job_detail(self):
+        fetcher = AppleFetcher("apple")
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"res": SAMPLE_JOB_DETAIL}
+        mock_response.raise_for_status = MagicMock()
+        fetcher.client = MagicMock()
+        fetcher.client.get.return_value = mock_response
+
+        job = fetcher.fetch_job("200660378-0157")
+        assert job.id == "200660378-0157"
+        assert job.title == "Manufacturing Design Program Manager (MDPM)"
+        # Description should combine summary + stripped HTML description
+        assert "Imagine what you could do here" in job.description
+        assert "full job description" in job.description
+        # HTML should be stripped
+        assert "<p>" not in job.description
+        assert "<b>" not in job.description
+
+    def test_fetch_job_api_headers(self):
+        """Verifies correct headers are sent to the detail API."""
+        fetcher = AppleFetcher("apple")
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"res": SAMPLE_JOB_DETAIL}
+        mock_response.raise_for_status = MagicMock()
+        fetcher.client = MagicMock()
+        fetcher.client.get.return_value = mock_response
+
+        fetcher.fetch_job("200660378-0157")
+
+        call_kwargs = fetcher.client.get.call_args
+        assert call_kwargs[1]["headers"]["content-type"] == "application/json"
+        assert call_kwargs[1]["headers"]["locale"] == "en-us"
+
+
+# ---------------------------------------------------------------------------
+# fetch_description tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchDescription:
+    def test_fetch_description_returns_text(self):
+        fetcher = AppleFetcher("apple")
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"res": SAMPLE_JOB_DETAIL}
+        mock_response.raise_for_status = MagicMock()
+        fetcher.client = MagicMock()
+        fetcher.client.get.return_value = mock_response
+
+        desc = fetcher.fetch_description("200660378-0157")
+        assert "Imagine what you could do here" in desc
+        assert "full job description" in desc
+
+
+# ---------------------------------------------------------------------------
+# URL parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestAppleURLParser:
+    def test_standard_url(self):
+        url = "https://jobs.apple.com/en-us/details/200660378-0157/manufacturing-design-program-manager-mdpm"
+        result = parse_url(url)
+        assert result == ParsedURL(ats="apple", board="apple", job_id="200660378-0157")
+
+    def test_different_locale(self):
+        url = "https://jobs.apple.com/de-de/details/200660378-0157/some-job"
+        result = parse_url(url)
+        assert result == ParsedURL(ats="apple", board="apple", job_id="200660378-0157")
+
+    def test_no_slug(self):
+        url = "https://jobs.apple.com/en-us/details/200660378-0157"
+        result = parse_url(url)
+        assert result == ParsedURL(ats="apple", board="apple", job_id="200660378-0157")
+
+    def test_non_apple_url_returns_none(self):
+        url = "https://boards.greenhouse.io/company/jobs/12345"
+        # Should be parsed by greenhouse, not apple
+        result = parse_url(url)
+        assert result is not None
+        assert result.ats == "greenhouse"


### PR DESCRIPTION
## Summary

- New `apple` fetcher that scrapes Apple's SSR hydration data (`window.__staticRouterHydrationData`) for job listings (20/page, ~6500 total jobs) and uses the unauthenticated `/api/v1/jobDetails/{id}` endpoint for full descriptions during enrichment
- Stub fetcher (`descriptions_in_listing = False`) — `list_jobs()` provides `jobSummary` as initial description, enrichment phase fetches full JD via detail API
- URL parser for `jobs.apple.com/{locale}/details/{positionId}/{slug}`
- 16 unit tests covering SSR parsing, location building, pagination, detail API, and URL parsing

## Test plan

- [x] All 16 unit tests pass (`tests/test_apple.py`)
- [x] Smoke tested `fetch_job()` against real Apple API — returns full description
- [x] Smoke tested SSR page parsing — correctly extracts 20 results from page 1
- [x] URL parser handles standard, alternate locale, and no-slug variants
- [ ] Register Apple via `jsb companies` and run `jsb sync --company apple` end-to-end

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)