### PR TITLE
Add Amazon.jobs fetcher

### DIFF
--- a/src/jobbuddy/fetchers/__init__.py
+++ b/src/jobbuddy/fetchers/__init__.py
@@ -1,5 +1,6 @@
 """ATS fetcher registry and factory."""
 
+from jobbuddy.fetchers.amazon import AmazonFetcher
 from jobbuddy.fetchers.ashby import AshbyFetcher
 from jobbuddy.fetchers.avature import AvatureFetcher
 from jobbuddy.fetchers.base import ATSFetcher
@@ -21,6 +22,7 @@ from jobbuddy.fetchers.workday import WorkdayFetcher
 from jobbuddy.models import Company
 
 _REGISTRY: dict[str, type[ATSFetcher]] = {
+    "amazon": AmazonFetcher,
     "ashby": AshbyFetcher,
     "avature": AvatureFetcher,
     "eightfold": EightfoldFetcher,

--- a/src/jobbuddy/fetchers/amazon.py
+++ b/src/jobbuddy/fetchers/amazon.py
@@ -11,6 +11,7 @@ Company registry fields:
 """
 
 import logging
+import re
 from datetime import date, datetime, timezone
 
 from jobbuddy.fetchers.base import ATSFetcher, JobList, ProgressCallback, RetryCallback
@@ -46,15 +47,13 @@ def _build_location(fields: dict) -> str:
 
 
 def _first(values: list | None) -> str | None:
-    if values and len(values) > 0:
+    if values:
         return values[0]
     return None
 
 
 def _slugify_title(title: str) -> str:
-    import re
-    slug = title.lower()
-    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower())
     return slug.strip("-")
 
 
@@ -187,16 +186,15 @@ class AmazonFetcher(ATSFetcher):
         return jobs
 
     def fetch_job(self, job_id: str) -> Job:
-        body = self._build_request_body(0, 1)
+        body = self._build_request_body(0, 10)
         body["query"] = job_id
 
-        resp = self.client.post(
-            SEARCH_URL,
-            json=body,
-            params={"is_als": "true"},
-        )
-        resp.raise_for_status()
-        data = resp.json()
+        def _do_fetch():
+            resp = self.client.post(SEARCH_URL, json=body, params={"is_als": "true"})
+            resp.raise_for_status()
+            return resp.json()
+
+        data = self._retry_request(_do_fetch)
 
         for hit in data.get("searchHits", []):
             fields = hit.get("fields", {})

--- a/src/jobbuddy/fetchers/amazon.py
+++ b/src/jobbuddy/fetchers/amazon.py
@@ -1,0 +1,206 @@
+"""Amazon.jobs fetcher.
+
+Uses the POST /api/jobs/search endpoint. No authentication required.
+Descriptions are included in listing results (full fetcher).
+
+Company registry fields:
+  - ats: "amazon"
+  - board: ignored (single global board)
+  - categories: list of category names to filter (e.g. ["Software Development"])
+  - country: optional ISO-2 country code filter (e.g. "US")
+"""
+
+import logging
+from datetime import date, datetime, timezone
+
+from jobbuddy.fetchers.base import ATSFetcher, JobList, ProgressCallback, RetryCallback
+from jobbuddy.models import Job, strip_html
+
+log = logging.getLogger(__name__)
+
+SEARCH_URL = "https://amazon.jobs/api/jobs/search"
+PAGE_SIZE = 500
+
+
+def _parse_epoch(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromtimestamp(int(value), tz=timezone.utc).date()
+    except (ValueError, OSError):
+        return None
+
+
+def _build_location(fields: dict) -> str:
+    parts = []
+    city = _first(fields.get("city"))
+    region = _first(fields.get("region"))
+    country = _first(fields.get("country"))
+    if city:
+        parts.append(city)
+    if region:
+        parts.append(region)
+    if country:
+        parts.append(country)
+    return ", ".join(parts)
+
+
+def _first(values: list | None) -> str | None:
+    if values and len(values) > 0:
+        return values[0]
+    return None
+
+
+def _slugify_title(title: str) -> str:
+    import re
+    slug = title.lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    return slug.strip("-")
+
+
+class AmazonFetcher(ATSFetcher):
+    ats_type = "amazon"
+
+    def __init__(
+        self,
+        board: str,
+        name: str | None = None,
+        *,
+        categories: list[str] | None = None,
+        country: str = "",
+    ):
+        super().__init__(board, name or "Amazon")
+        self.categories = categories or []
+        self.country = country
+        self.client.headers.update({
+            "Origin": "https://amazon.jobs",
+            "Referer": "https://amazon.jobs/",
+        })
+
+    def _build_request_body(self, start: int, size: int) -> dict:
+        filter_facets = []
+        if self.categories:
+            filter_facets.append({
+                "name": "category",
+                "requestedFacetCount": 9999,
+                "values": [{"name": c} for c in self.categories],
+            })
+        if self.country:
+            filter_facets.append({
+                "name": "country",
+                "requestedFacetCount": 9999,
+                "values": [{"name": self.country.upper()}],
+            })
+
+        return {
+            "accessLevel": "EXTERNAL",
+            "contentFilterFacets": [],
+            "excludeFacets": [
+                {"name": "isConfidential", "values": [{"name": "1"}]},
+                {"name": "businessCategory", "values": [{"name": "a-confidential-job"}]},
+            ],
+            "filterFacets": filter_facets,
+            "includeFacets": [],
+            "jobTypeFacets": [],
+            "locationFacets": [[
+                {"name": "country", "requestedFacetCount": 9999},
+                {"name": "normalizedStateName", "requestedFacetCount": 9999},
+                {"name": "normalizedCityName", "requestedFacetCount": 9999},
+            ]],
+            "query": "",
+            "size": size,
+            "start": start,
+            "treatment": "OM",
+            "sort": {"sortOrder": "DESCENDING", "sortType": "SCORE"},
+        }
+
+    def _parse_hit(self, hit: dict) -> Job:
+        fields = hit.get("fields", {})
+        job_id = _first(fields.get("icimsJobId")) or ""
+        title = _first(fields.get("title")) or ""
+        slug = _slugify_title(title)
+
+        description_html = _first(fields.get("description")) or ""
+        basic_quals = _first(fields.get("basicQualifications")) or ""
+        preferred_quals = _first(fields.get("preferredQualifications")) or ""
+
+        desc_parts = []
+        if description_html:
+            desc_parts.append(strip_html(description_html))
+        if basic_quals:
+            desc_parts.append("Basic Qualifications:\n" + strip_html(basic_quals))
+        if preferred_quals:
+            desc_parts.append("Preferred Qualifications:\n" + strip_html(preferred_quals))
+
+        description = "\n\n".join(desc_parts) if desc_parts else None
+
+        category = _first(fields.get("category"))
+        job_family = _first(fields.get("jobFamily"))
+        url_next_step = _first(fields.get("urlNextStep")) or ""
+
+        return Job(
+            id=job_id,
+            title=title,
+            location=_build_location(fields),
+            url=f"https://www.amazon.jobs/en/jobs/{job_id}/{slug}",
+            apply_url=url_next_step or f"https://account.amazon.jobs/jobs/{job_id}/apply",
+            published_at=_parse_epoch(_first(fields.get("createdDate"))),
+            department=category,
+            team=job_family,
+            description=description,
+        )
+
+    def list_jobs(
+        self,
+        *,
+        on_progress: ProgressCallback | None = None,
+        on_retry: RetryCallback | None = None,
+    ) -> JobList:
+        def _fetch_page(start: int) -> dict:
+            resp = self.client.post(
+                SEARCH_URL,
+                json=self._build_request_body(start, PAGE_SIZE),
+                params={"is_als": "true"},
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+        data = self._retry_request(lambda: _fetch_page(0), on_retry=on_retry)
+        total = data.get("found", 0)
+        hits = data.get("searchHits", [])
+        jobs: JobList = [self._parse_hit(h) for h in hits]
+
+        if on_progress:
+            on_progress(len(jobs), total)
+
+        start = len(hits)
+        while start < total:
+            page_data = self._retry_request(lambda s=start: _fetch_page(s), on_retry=on_retry)
+            page_hits = page_data.get("searchHits", [])
+            if not page_hits:
+                break
+            jobs.extend(self._parse_hit(h) for h in page_hits)
+            start += len(page_hits)
+            if on_progress:
+                on_progress(len(jobs), total)
+
+        return jobs
+
+    def fetch_job(self, job_id: str) -> Job:
+        body = self._build_request_body(0, 1)
+        body["query"] = job_id
+
+        resp = self.client.post(
+            SEARCH_URL,
+            json=body,
+            params={"is_als": "true"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        for hit in data.get("searchHits", []):
+            fields = hit.get("fields", {})
+            if _first(fields.get("icimsJobId")) == job_id:
+                return self._parse_hit(hit)
+
+        raise ValueError(f"Job ID {job_id} not found on Amazon.")

--- a/src/jobbuddy/url.py
+++ b/src/jobbuddy/url.py
@@ -484,6 +484,23 @@ def _parse_smartrecruiters(url: str) -> ParsedURL | None:
 
 
 # ---------------------------------------------------------------------------
+# Amazon
+# ---------------------------------------------------------------------------
+# https://www.amazon.jobs/en/jobs/{icimsJobId}/{slug}
+# https://amazon.jobs/en/jobs/{icimsJobId}/{slug}
+
+def _parse_amazon(url: str) -> ParsedURL | None:
+    m = re.search(
+        r"amazon\.jobs/[^/]+/jobs/(\d+)",
+        url,
+        re.IGNORECASE,
+    )
+    if m:
+        return ParsedURL(ats="amazon", board="amazon", job_id=m.group(1))
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -504,6 +521,7 @@ _PARSERS = [
     _parse_jibe,
     _parse_jobsync,
     _parse_smartrecruiters,
+    _parse_amazon,
 ]
 
 

--- a/tests/test_amazon_fetcher.py
+++ b/tests/test_amazon_fetcher.py
@@ -185,3 +185,52 @@ def test_list_jobs_pagination(monkeypatch):
     assert len(jobs) == 700
     assert len(calls) == 2
     assert progress_calls[-1] == (700, 700)
+
+
+# ---------------------------------------------------------------------------
+# fetch_job (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+def test_fetch_job_found(monkeypatch):
+    hit = {"fields": {"icimsJobId": ["12345"], "title": ["Test Engineer"]}}
+    f = AmazonFetcher("")
+
+    def mock_post(*args, **kwargs):
+        body = kwargs.get("json", {})
+        assert body["query"] == "12345"
+        return _make_search_response([hit], found=1)
+
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    job = f.fetch_job("12345")
+    assert job.id == "12345"
+    assert job.title == "Test Engineer"
+
+
+def test_fetch_job_not_found(monkeypatch):
+    f = AmazonFetcher("")
+
+    def mock_post(*args, **kwargs):
+        return _make_search_response([], found=0)
+
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    with pytest.raises(ValueError, match="not found"):
+        f.fetch_job("99999")
+
+
+def test_fetch_job_filters_by_id(monkeypatch):
+    hits = [
+        {"fields": {"icimsJobId": ["111"], "title": ["Wrong Job"]}},
+        {"fields": {"icimsJobId": ["222"], "title": ["Right Job"]}},
+    ]
+    f = AmazonFetcher("")
+
+    def mock_post(*args, **kwargs):
+        return _make_search_response(hits, found=2)
+
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    job = f.fetch_job("222")
+    assert job.id == "222"
+    assert job.title == "Right Job"

--- a/tests/test_amazon_fetcher.py
+++ b/tests/test_amazon_fetcher.py
@@ -1,0 +1,187 @@
+"""Tests for the Amazon.jobs fetcher."""
+
+import json
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from jobbuddy.fetchers.amazon import AmazonFetcher, _parse_epoch
+from jobbuddy.url import parse_url
+
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("url,expected_id", [
+    ("https://www.amazon.jobs/en/jobs/10406569/software-development-engineer-aws", "10406569"),
+    ("https://amazon.jobs/en/jobs/10406569/software-development-engineer-aws", "10406569"),
+    ("https://www.amazon.jobs/en-gb/jobs/2345678/some-role-title", "2345678"),
+])
+def test_parse_amazon_url(url, expected_id):
+    result = parse_url(url)
+    assert result is not None
+    assert result.ats == "amazon"
+    assert result.job_id == expected_id
+    assert result.board == "amazon"
+
+
+def test_parse_amazon_url_rejects_non_amazon():
+    assert parse_url("https://example.com/en/jobs/12345/foo") is None
+
+
+# ---------------------------------------------------------------------------
+# Epoch date parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_epoch_valid():
+    assert _parse_epoch("1776450511") is not None
+
+def test_parse_epoch_none():
+    assert _parse_epoch(None) is None
+    assert _parse_epoch("") is None
+
+def test_parse_epoch_invalid():
+    assert _parse_epoch("not-a-number") is None
+
+
+# ---------------------------------------------------------------------------
+# Fetcher construction
+# ---------------------------------------------------------------------------
+
+def test_fetcher_defaults():
+    f = AmazonFetcher("", name="Amazon")
+    assert f.ats_type == "amazon"
+    assert f.name == "Amazon"
+    assert f.categories == []
+    assert f.country == ""
+    assert f.descriptions_in_listing is True
+
+
+def test_fetcher_with_filters():
+    f = AmazonFetcher("", categories=["Software Development", "Data Science"], country="US")
+    body = f._build_request_body(0, 10)
+    filter_names = [fac["name"] for fac in body["filterFacets"]]
+    assert "category" in filter_names
+    assert "country" in filter_names
+
+    cat_facet = next(f for f in body["filterFacets"] if f["name"] == "category")
+    assert len(cat_facet["values"]) == 2
+
+
+def test_fetcher_no_filters():
+    f = AmazonFetcher("")
+    body = f._build_request_body(0, 10)
+    assert body["filterFacets"] == []
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+SAMPLE_HIT = {
+    "fields": {
+        "icimsJobId": ["10406569"],
+        "title": ["Software Development Engineer, AWS Transform"],
+        "city": ["Seattle"],
+        "region": ["WA"],
+        "country": ["US"],
+        "description": ["<p>Some description</p>"],
+        "basicQualifications": ["<p>3+ years experience</p>"],
+        "preferredQualifications": ["<p>5+ years experience</p>"],
+        "category": ["Software Development"],
+        "jobFamily": ["Software Development"],
+        "createdDate": ["1776450511"],
+        "urlNextStep": ["https://account.amazon.jobs/jobs/10406569/apply"],
+    }
+}
+
+
+def test_parse_hit():
+    f = AmazonFetcher("")
+    job = f._parse_hit(SAMPLE_HIT)
+    assert job.id == "10406569"
+    assert job.title == "Software Development Engineer, AWS Transform"
+    assert "Seattle" in job.location
+    assert "WA" in job.location
+    assert job.department == "Software Development"
+    assert job.team == "Software Development"
+    assert job.description is not None
+    assert "Some description" in job.description
+    assert "Basic Qualifications:" in job.description
+    assert "Preferred Qualifications:" in job.description
+    assert job.url == "https://www.amazon.jobs/en/jobs/10406569/software-development-engineer-aws-transform"
+    assert job.apply_url == "https://account.amazon.jobs/jobs/10406569/apply"
+    assert job.published_at is not None
+
+
+def test_parse_hit_missing_fields():
+    f = AmazonFetcher("")
+    hit = {"fields": {"icimsJobId": ["99999"], "title": ["Test Role"]}}
+    job = f._parse_hit(hit)
+    assert job.id == "99999"
+    assert job.title == "Test Role"
+    assert job.location == ""
+    assert job.description is None
+
+
+# ---------------------------------------------------------------------------
+# list_jobs pagination (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+def _make_search_response(hits: list[dict], found: int) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"found": found, "searchHits": hits, "start": 0, "facets": []},
+        request=httpx.Request("POST", "https://amazon.jobs/api/jobs/search"),
+    )
+
+
+def test_list_jobs_single_page(monkeypatch):
+    hits = [
+        {"fields": {"icimsJobId": [str(i)], "title": [f"Job {i}"]}}
+        for i in range(3)
+    ]
+    f = AmazonFetcher("", categories=["Software Development"])
+
+    call_count = 0
+    def mock_post(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return _make_search_response(hits, found=3)
+
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    jobs = f.list_jobs()
+    assert len(jobs) == 3
+    assert call_count == 1
+
+
+def test_list_jobs_pagination(monkeypatch):
+    page1_hits = [
+        {"fields": {"icimsJobId": [str(i)], "title": [f"Job {i}"]}}
+        for i in range(500)
+    ]
+    page2_hits = [
+        {"fields": {"icimsJobId": [str(i)], "title": [f"Job {i}"]}}
+        for i in range(500, 700)
+    ]
+
+    f = AmazonFetcher("")
+    calls = []
+
+    def mock_post(*args, **kwargs):
+        body = kwargs.get("json", {})
+        calls.append(body.get("start", 0))
+        if body.get("start", 0) == 0:
+            return _make_search_response(page1_hits, found=700)
+        return _make_search_response(page2_hits, found=700)
+
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    progress_calls = []
+    jobs = f.list_jobs(on_progress=lambda fetched, total: progress_calls.append((fetched, total)))
+    assert len(jobs) == 700
+    assert len(calls) == 2
+    assert progress_calls[-1] == (700, 700)


### PR DESCRIPTION
## Summary

- New `AmazonFetcher` using the POST `/api/jobs/search` endpoint (no auth required)
- Full fetcher — descriptions, basic qualifications, and preferred qualifications included in listing results
- Supports `categories` (e.g. `["Software Development"]`) and `country` (e.g. `"US"`) filtering via facets
- URL parser for `amazon.jobs/en/jobs/{id}/{slug}` pattern
- 14 unit tests covering URL parsing, response parsing, filtering, and pagination

Closes #32

## Registration example

```python
register_company("Amazon", ats="amazon", categories=["Software Development"], country="US")
```

## Test plan

- [x] Unit tests pass (14/14)
- [x] Live smoke test: fetched 1,006 US Software Development jobs
- [x] `fetch_job("10406569")` resolves correctly
- [x] Full test suite: no regressions (24 pre-existing failures, 263 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)