### PR TITLE
Add Google Careers fetcher

### DIFF
--- a/src/jobbuddy/fetchers/__init__.py
+++ b/src/jobbuddy/fetchers/__init__.py
@@ -7,6 +7,7 @@ from jobbuddy.fetchers.avature import AvatureFetcher
 from jobbuddy.fetchers.base import ATSFetcher
 from jobbuddy.fetchers.eightfold import EightfoldFetcher
 from jobbuddy.fetchers.eightfold_v2 import EightfoldV2Fetcher
+from jobbuddy.fetchers.google import GoogleFetcher
 from jobbuddy.fetchers.greenhouse import GreenhouseFetcher
 from jobbuddy.fetchers.jibe import JibeFetcher
 from jobbuddy.fetchers.jobsync import JobSyncFetcher
@@ -29,6 +30,7 @@ _REGISTRY: dict[str, type[ATSFetcher]] = {
     "avature": AvatureFetcher,
     "eightfold": EightfoldFetcher,
     "eightfold_v2": EightfoldV2Fetcher,
+    "google": GoogleFetcher,
     "greenhouse": GreenhouseFetcher,
     "jibe": JibeFetcher,
     "jobsync": JobSyncFetcher,

--- a/src/jobbuddy/fetchers/google.py
+++ b/src/jobbuddy/fetchers/google.py
@@ -14,6 +14,8 @@ import re
 import urllib.parse
 from datetime import datetime, timezone
 
+import httpx
+
 from jobbuddy.fetchers.base import ATSFetcher, JobList, ProgressCallback, RetryCallback
 from jobbuddy.models import Job, strip_html
 
@@ -23,6 +25,7 @@ CAREERS_URL = "https://www.google.com/about/careers/applications/jobs/results"
 BATCHEXECUTE_PATH = "/about/careers/applications/_/HiringCportalFrontendUi/data/batchexecute"
 RPC_ID = "r06xKb"
 PAGE_SIZE = 20
+MAX_PAGES = 500
 
 
 def extract_tokens(html: str) -> tuple[str, str]:
@@ -48,26 +51,23 @@ def build_location(location_entries: list | None) -> str:
     return " | ".join(names)
 
 
+def _get_nested(entry: list, idx: int) -> str | None:
+    """Safely extract a nested HTML string from entry[idx][1]."""
+    if idx >= len(entry) or not entry[idx]:
+        return None
+    val = entry[idx]
+    if isinstance(val, list) and len(val) > 1:
+        return val[1]
+    return None
+
+
 def build_description(entry: list) -> str | None:
     """Combine summary, description, qualifications, and workplace info."""
     parts = []
-
-    summary = entry[10][1] if entry[10] else None
-    if summary:
-        parts.append(strip_html(summary))
-
-    desc = entry[3][1] if entry[3] else None
-    if desc:
-        parts.append(strip_html(desc))
-
-    quals = entry[4][1] if entry[4] else None
-    if quals:
-        parts.append(strip_html(quals))
-
-    workplace = entry[18][1] if len(entry) > 18 and entry[18] else None
-    if workplace:
-        parts.append(strip_html(workplace))
-
+    for idx in (10, 3, 4, 18):
+        html = _get_nested(entry, idx)
+        if html:
+            parts.append(strip_html(html))
     return "\n\n".join(parts) if parts else None
 
 
@@ -132,33 +132,41 @@ class GoogleFetcher(ATSFetcher):
         html = self._retry_request(do_fetch, on_retry=on_retry)
         self._f_sid, self._bl = extract_tokens(html)
 
+    def _clear_tokens(self) -> None:
+        self._f_sid = None
+        self._bl = None
+
     def _fetch_page(
         self, page: int, *, include_count: bool = False, on_retry: RetryCallback | None = None,
     ) -> tuple[list[list], int | None]:
-        """Fetch a page of results. Returns (job_entries, total_or_none)."""
+        """Fetch a page of results. Returns (job_entries, total_or_none).
+
+        On non-retryable HTTP errors (400/403), clears cached tokens and
+        retries once — Google rotates f.sid periodically.
+        """
         self._ensure_tokens(on_retry=on_retry)
 
-        payload: list = ["", None, None, None, "en", None, None, page]
-        if include_count:
-            payload.extend([None, 1])
-        inner = json.dumps([payload])
-        outer = [[RPC_ID, inner, None, "3"]]
-        f_req = json.dumps([outer])
-
-        params = {
-            "rpcids": RPC_ID,
-            "source-path": "/about/careers/applications/jobs/results",
-            "f.sid": self._f_sid,
-            "bl": self._bl,
-            "hl": "en",
-            "soc-app": "1",
-            "soc-platform": "1",
-            "soc-device": "1",
-            "_reqid": str(100000 + page * 100000),
-            "rt": "c",
-        }
-
         def do_fetch():
+            payload: list = ["", None, None, None, "en", None, None, page]
+            if include_count:
+                payload.extend([None, 1])
+            inner = json.dumps([payload])
+            outer = [[RPC_ID, inner, None, "3"]]
+            f_req = json.dumps([outer])
+
+            params = {
+                "rpcids": RPC_ID,
+                "source-path": "/about/careers/applications/jobs/results",
+                "f.sid": self._f_sid,
+                "bl": self._bl,
+                "hl": "en",
+                "soc-app": "1",
+                "soc-platform": "1",
+                "soc-device": "1",
+                "_reqid": str(100000 + page * 100000),
+                "rt": "c",
+            }
+
             resp = self.client.post(
                 f"https://www.google.com{BATCHEXECUTE_PATH}",
                 params=params,
@@ -168,25 +176,36 @@ class GoogleFetcher(ATSFetcher):
             resp.raise_for_status()
             return resp.text
 
-        raw = self._retry_request(do_fetch, on_retry=on_retry)
-        data = parse_batchexecute_response(raw)
+        try:
+            raw = self._retry_request(do_fetch, on_retry=on_retry)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code in (400, 403):
+                log.info("Got %d, refreshing tokens", e.response.status_code)
+                self._clear_tokens()
+                self._ensure_tokens(on_retry=on_retry)
+                raw = self._retry_request(do_fetch, on_retry=on_retry)
+            else:
+                raise
 
+        data = parse_batchexecute_response(raw)
         entries = data[0] if data[0] else []
         total = data[2] if include_count and len(data) > 2 else None
         return entries, total
 
     def _entry_to_job(self, entry: list) -> Job:
         job_id = str(entry[0])
-        title = entry[1] or ""
+        title = entry[1] or "" if len(entry) > 1 else ""
+        apply_url = entry[2] if len(entry) > 2 else None
         locations = entry[9] if len(entry) > 9 else None
+        timestamp = entry[12] if len(entry) > 12 else None
 
         return Job(
             id=job_id,
             title=title,
             location=build_location(locations),
             url=f"{CAREERS_URL}/{job_id}",
-            apply_url=entry[2] or f"{CAREERS_URL}/{job_id}",
-            published_at=parse_timestamp(entry[12] if len(entry) > 12 else None),
+            apply_url=apply_url or f"{CAREERS_URL}/{job_id}",
+            published_at=parse_timestamp(timestamp),
             department=None,
             description=build_description(entry),
         )
@@ -213,7 +232,7 @@ class GoogleFetcher(ATSFetcher):
             on_progress(len(jobs), reported_total or len(jobs))
 
         page = 2
-        while True:
+        while page < MAX_PAGES:
             page_entries, _ = self._fetch_page(page, on_retry=on_retry)
             if not page_entries:
                 break
@@ -233,7 +252,11 @@ class GoogleFetcher(ATSFetcher):
         return jobs
 
     def fetch_job(self, job_id: str) -> Job:
-        for page in range(1, 100):
+        log.warning(
+            "Google fetch_job requires paginating through all listings "
+            "(no search-by-ID API) — this may be slow",
+        )
+        for page in range(1, MAX_PAGES):
             entries, _ = self._fetch_page(page)
             if not entries:
                 break

--- a/src/jobbuddy/fetchers/google.py
+++ b/src/jobbuddy/fetchers/google.py
@@ -1,0 +1,244 @@
+"""Google Careers fetcher (google.com/about/careers/applications).
+
+Uses Google's internal batchexecute RPC protocol. No authentication required
+for public listings. Descriptions are included in listing results (full fetcher).
+
+Company registry fields:
+  - ats: "google"
+  - board: ignored (single global careers portal)
+"""
+
+import json
+import logging
+import re
+import urllib.parse
+from datetime import datetime, timezone
+
+from jobbuddy.fetchers.base import ATSFetcher, JobList, ProgressCallback, RetryCallback
+from jobbuddy.models import Job, strip_html
+
+log = logging.getLogger(__name__)
+
+CAREERS_URL = "https://www.google.com/about/careers/applications/jobs/results"
+BATCHEXECUTE_PATH = "/about/careers/applications/_/HiringCportalFrontendUi/data/batchexecute"
+RPC_ID = "r06xKb"
+PAGE_SIZE = 20
+
+
+def extract_tokens(html: str) -> tuple[str, str]:
+    """Extract f.sid and bl (build label) from the careers page HTML.
+
+    Raises ValueError if tokens cannot be found.
+    """
+    sid_match = re.search(r'"FdrFJe":"(-?\d+)"', html)
+    if not sid_match:
+        raise ValueError("Could not extract f.sid from Google careers page")
+
+    bl_match = re.search(r'"cfb2h":"(boq_[^"]+)"', html)
+    if not bl_match:
+        raise ValueError("Could not extract build label from Google careers page")
+
+    return sid_match.group(1), bl_match.group(1)
+
+
+def build_location(location_entries: list | None) -> str:
+    if not location_entries:
+        return ""
+    names = [entry[0] for entry in location_entries if entry and entry[0]]
+    return " | ".join(names)
+
+
+def build_description(entry: list) -> str | None:
+    """Combine summary, description, qualifications, and workplace info."""
+    parts = []
+
+    summary = entry[10][1] if entry[10] else None
+    if summary:
+        parts.append(strip_html(summary))
+
+    desc = entry[3][1] if entry[3] else None
+    if desc:
+        parts.append(strip_html(desc))
+
+    quals = entry[4][1] if entry[4] else None
+    if quals:
+        parts.append(strip_html(quals))
+
+    workplace = entry[18][1] if len(entry) > 18 and entry[18] else None
+    if workplace:
+        parts.append(strip_html(workplace))
+
+    return "\n\n".join(parts) if parts else None
+
+
+def parse_timestamp(ts: list | None) -> str | None:
+    if not ts or not ts[0]:
+        return None
+    try:
+        dt = datetime.fromtimestamp(ts[0], tz=timezone.utc)
+        return dt.strftime("%Y-%m-%d")
+    except (ValueError, OSError, TypeError):
+        return None
+
+
+def parse_batchexecute_response(text: str) -> list:
+    """Parse the batchexecute response format.
+
+    Response starts with )]}'\\n then alternates between byte-count lines
+    and JSON array lines. We find the JSON envelope for our RPC.
+    """
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line.startswith("["):
+            continue
+        try:
+            envelope = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            isinstance(envelope, list)
+            and envelope
+            and isinstance(envelope[0], list)
+            and len(envelope[0]) > 2
+            and envelope[0][1] == RPC_ID
+        ):
+            return json.loads(envelope[0][2])
+
+    raise ValueError("Could not find r06xKb response in batchexecute output")
+
+
+class GoogleFetcher(ATSFetcher):
+    ats_type = "google"
+
+    def __init__(self, board: str, name: str | None = None):
+        super().__init__(board, name or "Google")
+        self._f_sid: str | None = None
+        self._bl: str | None = None
+        self.client.headers.update({
+            "Origin": "https://www.google.com",
+            "Referer": "https://www.google.com/",
+            "X-Same-Domain": "1",
+        })
+
+    def _ensure_tokens(self, *, on_retry: RetryCallback | None = None) -> None:
+        if self._f_sid and self._bl:
+            return
+
+        def do_fetch():
+            resp = self.client.get(CAREERS_URL)
+            resp.raise_for_status()
+            return resp.text
+
+        html = self._retry_request(do_fetch, on_retry=on_retry)
+        self._f_sid, self._bl = extract_tokens(html)
+
+    def _fetch_page(
+        self, page: int, *, include_count: bool = False, on_retry: RetryCallback | None = None,
+    ) -> tuple[list[list], int | None]:
+        """Fetch a page of results. Returns (job_entries, total_or_none)."""
+        self._ensure_tokens(on_retry=on_retry)
+
+        payload: list = ["", None, None, None, "en", None, None, page]
+        if include_count:
+            payload.extend([None, 1])
+        inner = json.dumps([payload])
+        outer = [[RPC_ID, inner, None, "3"]]
+        f_req = json.dumps([outer])
+
+        params = {
+            "rpcids": RPC_ID,
+            "source-path": "/about/careers/applications/jobs/results",
+            "f.sid": self._f_sid,
+            "bl": self._bl,
+            "hl": "en",
+            "soc-app": "1",
+            "soc-platform": "1",
+            "soc-device": "1",
+            "_reqid": str(100000 + page * 100000),
+            "rt": "c",
+        }
+
+        def do_fetch():
+            resp = self.client.post(
+                f"https://www.google.com{BATCHEXECUTE_PATH}",
+                params=params,
+                content=f"f.req={urllib.parse.quote(f_req)}&",
+                headers={"Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"},
+            )
+            resp.raise_for_status()
+            return resp.text
+
+        raw = self._retry_request(do_fetch, on_retry=on_retry)
+        data = parse_batchexecute_response(raw)
+
+        entries = data[0] if data[0] else []
+        total = data[2] if include_count and len(data) > 2 else None
+        return entries, total
+
+    def _entry_to_job(self, entry: list) -> Job:
+        job_id = str(entry[0])
+        title = entry[1] or ""
+        locations = entry[9] if len(entry) > 9 else None
+
+        return Job(
+            id=job_id,
+            title=title,
+            location=build_location(locations),
+            url=f"{CAREERS_URL}/{job_id}",
+            apply_url=entry[2] or f"{CAREERS_URL}/{job_id}",
+            published_at=parse_timestamp(entry[12] if len(entry) > 12 else None),
+            department=None,
+            description=build_description(entry),
+        )
+
+    def list_jobs(
+        self,
+        *,
+        on_progress: ProgressCallback | None = None,
+        on_retry: RetryCallback | None = None,
+    ) -> JobList:
+        # Google's reported total is unreliable (often undercounts), so we
+        # paginate until we get an empty page or zero new unique jobs.
+        entries, reported_total = self._fetch_page(1, include_count=True, on_retry=on_retry)
+        seen: set[str] = set()
+        jobs: JobList = []
+
+        for e in entries:
+            jid = str(e[0])
+            if jid not in seen:
+                seen.add(jid)
+                jobs.append(self._entry_to_job(e))
+
+        if on_progress:
+            on_progress(len(jobs), reported_total or len(jobs))
+
+        page = 2
+        while True:
+            page_entries, _ = self._fetch_page(page, on_retry=on_retry)
+            if not page_entries:
+                break
+            new_count = 0
+            for e in page_entries:
+                jid = str(e[0])
+                if jid not in seen:
+                    seen.add(jid)
+                    jobs.append(self._entry_to_job(e))
+                    new_count += 1
+            if new_count == 0:
+                break
+            if on_progress:
+                on_progress(len(jobs), max(len(jobs), reported_total or 0))
+            page += 1
+
+        return jobs
+
+    def fetch_job(self, job_id: str) -> Job:
+        for page in range(1, 100):
+            entries, _ = self._fetch_page(page)
+            if not entries:
+                break
+            for entry in entries:
+                if str(entry[0]) == job_id:
+                    return self._entry_to_job(entry)
+
+        raise ValueError(f"Job ID {job_id} not found on Google Careers")

--- a/src/jobbuddy/url.py
+++ b/src/jobbuddy/url.py
@@ -518,6 +518,21 @@ def _parse_amazon(url: str) -> ParsedURL | None:
 
 
 # ---------------------------------------------------------------------------
+# Google Careers
+# ---------------------------------------------------------------------------
+# https://www.google.com/about/careers/applications/jobs/results/{job_id}
+
+def _parse_google(url: str) -> ParsedURL | None:
+    m = re.search(
+        r"google\.com/about/careers/applications/jobs/results/(\d+)",
+        url,
+    )
+    if m:
+        return ParsedURL(ats="google", board="google", job_id=m.group(1))
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -540,6 +555,7 @@ _PARSERS = [
     _parse_smartrecruiters,
     _parse_amazon,
     _parse_apple,
+    _parse_google,
 ]
 
 

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -147,6 +147,16 @@ def test_build_description_all_none():
     assert desc is None
 
 
+def test_build_description_short_entry():
+    """Short entry arrays (fewer than 19 elements) should not IndexError."""
+    entry = [None] * 5
+    entry[0] = "123"
+    entry[3] = [None, "<p>Short listing</p>"]
+    desc = build_description(entry)
+    assert desc is not None
+    assert "Short listing" in desc
+
+
 # ---------------------------------------------------------------------------
 # Batchexecute response parsing
 # ---------------------------------------------------------------------------
@@ -221,6 +231,16 @@ def test_entry_to_job_minimal():
     assert job.title == "Intern"
     assert job.location == ""
     assert "999" in job.url
+
+
+def test_entry_to_job_short_entry():
+    """Entry with only a few elements should not IndexError."""
+    f = GoogleFetcher("")
+    entry = ["888"]
+    job = f._entry_to_job(entry)
+    assert job.id == "888"
+    assert job.title == ""
+    assert job.location == ""
 
 
 # ---------------------------------------------------------------------------
@@ -394,3 +414,41 @@ def test_fetch_job_not_found(monkeypatch):
 
     with pytest.raises(ValueError, match="not found"):
         f.fetch_job("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# Token refresh on stale tokens (issue 3)
+# ---------------------------------------------------------------------------
+
+def test_token_refresh_on_403(monkeypatch):
+    """Stale tokens should be refreshed on 403 and the request retried."""
+    import httpx as _httpx
+
+    entries = [_make_entry(id="1", title="Job 1")]
+    f = GoogleFetcher("")
+
+    get_calls = 0
+    post_calls = 0
+
+    def mock_get(*args, **kwargs):
+        nonlocal get_calls
+        get_calls += 1
+        return _mock_careers_page()
+
+    def mock_post(*args, **kwargs):
+        nonlocal post_calls
+        post_calls += 1
+        if post_calls == 1:
+            raise _httpx.HTTPStatusError(
+                "Forbidden",
+                request=_httpx.Request("POST", "https://example.com"),
+                response=_httpx.Response(403),
+            )
+        return _mock_batchexecute_response(entries, total=1)
+
+    monkeypatch.setattr(f.client, "get", mock_get)
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    jobs = f.list_jobs()
+    assert len(jobs) == 1
+    assert get_calls == 2  # initial + refresh

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -1,0 +1,396 @@
+"""Tests for the Google Careers fetcher."""
+
+import json
+
+import httpx
+import pytest
+
+from jobbuddy.fetchers.google import (
+    GoogleFetcher,
+    build_description,
+    build_location,
+    extract_tokens,
+    parse_batchexecute_response,
+    parse_timestamp,
+)
+from jobbuddy.url import parse_url
+
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_google_url():
+    result = parse_url("https://www.google.com/about/careers/applications/jobs/results/101886789328741062")
+    assert result is not None
+    assert result.ats == "google"
+    assert result.job_id == "101886789328741062"
+    assert result.board == "google"
+
+
+def test_parse_google_url_rejects_non_google():
+    assert parse_url("https://example.com/about/careers/applications/jobs/results/123") is None
+
+
+# ---------------------------------------------------------------------------
+# Token extraction
+# ---------------------------------------------------------------------------
+
+MOCK_HTML = """
+<html><head><script>
+window.WIZ_global_data = {
+  "FdrFJe":"-1234567890",
+  "cfb2h":"boq_corp-hiring-boq-cportal-frontend_20260426.07_p0"
+};
+</script></head></html>
+"""
+
+
+def test_extract_tokens():
+    f_sid, bl = extract_tokens(MOCK_HTML)
+    assert f_sid == "-1234567890"
+    assert bl == "boq_corp-hiring-boq-cportal-frontend_20260426.07_p0"
+
+
+def test_extract_tokens_missing_sid():
+    with pytest.raises(ValueError, match="f.sid"):
+        extract_tokens("<html></html>")
+
+
+def test_extract_tokens_missing_bl():
+    html = '<script>"FdrFJe":"-123"</script>'
+    with pytest.raises(ValueError, match="build label"):
+        extract_tokens(html)
+
+
+# ---------------------------------------------------------------------------
+# Location building
+# ---------------------------------------------------------------------------
+
+def test_build_location_single():
+    locs = [["Mountain View, CA, USA", ["Mountain View"], None, None, None, "US"]]
+    assert build_location(locs) == "Mountain View, CA, USA"
+
+
+def test_build_location_multiple():
+    locs = [
+        ["Texas, USA", ["Texas"], None, None, None, "US"],
+        ["California, USA", ["California"], None, None, None, "US"],
+    ]
+    assert build_location(locs) == "Texas, USA | California, USA"
+
+
+def test_build_location_none():
+    assert build_location(None) == ""
+
+
+def test_build_location_empty():
+    assert build_location([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Timestamp parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_timestamp_valid():
+    assert parse_timestamp([1777024853, 467000000]) == "2026-04-24"
+
+
+def test_parse_timestamp_none():
+    assert parse_timestamp(None) is None
+    assert parse_timestamp([None]) is None
+
+
+def test_parse_timestamp_empty():
+    assert parse_timestamp([]) is None
+
+
+# ---------------------------------------------------------------------------
+# Description building
+# ---------------------------------------------------------------------------
+
+def _make_entry(**overrides):
+    """Build a minimal 21-element job entry array."""
+    entry = [None] * 21
+    entry[0] = overrides.get("id", "123")
+    entry[1] = overrides.get("title", "Test Job")
+    entry[2] = overrides.get("apply_url", "https://example.com/apply")
+    entry[3] = overrides.get("description", [None, "<p>Job responsibilities</p>"])
+    entry[4] = overrides.get("qualifications", [None, "<h3>Minimum qualifications:</h3><ul><li>BS degree</li></ul>"])
+    entry[9] = overrides.get("locations", [["Mountain View, CA, USA"]])
+    entry[10] = overrides.get("summary", [None, "<p>About the role</p>"])
+    entry[12] = overrides.get("timestamp", [1777024853, 467000000])
+    entry[18] = overrides.get("workplace", [None, "<b>Remote location: USA</b>"])
+    return entry
+
+
+def test_build_description_full():
+    entry = _make_entry()
+    desc = build_description(entry)
+    assert desc is not None
+    assert "About the role" in desc
+    assert "Job responsibilities" in desc
+    assert "BS degree" in desc
+    assert "Remote location: USA" in desc
+
+
+def test_build_description_missing_sections():
+    entry = _make_entry(description=None, qualifications=None, workplace=None)
+    desc = build_description(entry)
+    assert desc is not None
+    assert "About the role" in desc
+
+
+def test_build_description_all_none():
+    entry = _make_entry(summary=None, description=None, qualifications=None, workplace=None)
+    desc = build_description(entry)
+    assert desc is None
+
+
+# ---------------------------------------------------------------------------
+# Batchexecute response parsing
+# ---------------------------------------------------------------------------
+
+def _make_batchexecute_response(jobs_data, total=None, page_size=20):
+    """Build a mock batchexecute response string."""
+    inner = [jobs_data, None, total, page_size]
+    inner_json = json.dumps(inner)
+    envelope = json.dumps([["wrb.fr", "r06xKb", inner_json, None, None, None, "generic"]])
+    return ")]" + "}'\n\n" + str(len(envelope)) + "\n" + envelope
+
+
+def test_parse_batchexecute_response():
+    entries = [[_make_entry()]]
+    raw = _make_batchexecute_response(entries[0], total=1)
+    data = parse_batchexecute_response(raw)
+    assert len(data[0]) == 1
+    assert data[2] == 1
+
+
+def test_parse_batchexecute_response_empty():
+    raw = _make_batchexecute_response([], total=0)
+    data = parse_batchexecute_response(raw)
+    assert data[0] == []
+
+
+def test_parse_batchexecute_response_invalid():
+    with pytest.raises(ValueError, match="Could not find"):
+        parse_batchexecute_response(")]}'\n\n5\n[1,2]")
+
+
+# ---------------------------------------------------------------------------
+# Fetcher construction
+# ---------------------------------------------------------------------------
+
+def test_fetcher_defaults():
+    f = GoogleFetcher("", name="Google")
+    assert f.ats_type == "google"
+    assert f.name == "Google"
+    assert f.descriptions_in_listing is True
+
+
+# ---------------------------------------------------------------------------
+# Entry → Job mapping
+# ---------------------------------------------------------------------------
+
+def test_entry_to_job():
+    f = GoogleFetcher("")
+    entry = _make_entry(
+        id="12345678901234567",
+        title="Software Engineer, Cloud",
+        apply_url="https://google.com/apply/xyz",
+    )
+    job = f._entry_to_job(entry)
+    assert job.id == "12345678901234567"
+    assert job.title == "Software Engineer, Cloud"
+    assert job.location == "Mountain View, CA, USA"
+    assert "12345678901234567" in job.url
+    assert job.apply_url == "https://google.com/apply/xyz"
+    assert job.published_at is not None
+    assert job.description is not None
+
+
+def test_entry_to_job_minimal():
+    f = GoogleFetcher("")
+    entry = [None] * 21
+    entry[0] = "999"
+    entry[1] = "Intern"
+    entry[2] = None
+    job = f._entry_to_job(entry)
+    assert job.id == "999"
+    assert job.title == "Intern"
+    assert job.location == ""
+    assert "999" in job.url
+
+
+# ---------------------------------------------------------------------------
+# list_jobs (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+def _mock_careers_page() -> httpx.Response:
+    return httpx.Response(
+        200,
+        text=MOCK_HTML,
+        request=httpx.Request("GET", "https://www.google.com/about/careers/applications/jobs/results"),
+    )
+
+
+def _mock_batchexecute_response(entries, total=None, page_size=20) -> httpx.Response:
+    inner = [entries, None, total, page_size]
+    inner_json = json.dumps(inner)
+    envelope = json.dumps([["wrb.fr", "r06xKb", inner_json, None, None, None, "generic"]])
+    body = ")]" + "}'\n\n" + str(len(envelope)) + "\n" + envelope
+    return httpx.Response(
+        200,
+        text=body,
+        request=httpx.Request("POST", "https://www.google.com/batchexecute"),
+    )
+
+
+def test_list_jobs_single_page(monkeypatch):
+    entries = [_make_entry(id=str(i), title=f"Job {i}") for i in range(5)]
+    f = GoogleFetcher("")
+
+    call_count = 0
+
+    def mock_get(*args, **kwargs):
+        return _mock_careers_page()
+
+    def mock_post(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _mock_batchexecute_response(entries, total=5)
+        return _mock_batchexecute_response([], total=5)
+
+    monkeypatch.setattr(f.client, "get", mock_get)
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    jobs = f.list_jobs()
+    assert len(jobs) == 5
+
+
+def test_list_jobs_pagination(monkeypatch):
+    page1 = [_make_entry(id=str(i), title=f"Job {i}") for i in range(20)]
+    page2 = [_make_entry(id=str(i), title=f"Job {i}") for i in range(20, 35)]
+
+    f = GoogleFetcher("")
+    post_calls = 0
+
+    def mock_get(*args, **kwargs):
+        return _mock_careers_page()
+
+    def mock_post(*args, **kwargs):
+        nonlocal post_calls
+        post_calls += 1
+        if post_calls == 1:
+            return _mock_batchexecute_response(page1, total=35)
+        if post_calls == 2:
+            return _mock_batchexecute_response(page2, total=35)
+        return _mock_batchexecute_response([], total=35)
+
+    monkeypatch.setattr(f.client, "get", mock_get)
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    progress = []
+    jobs = f.list_jobs(on_progress=lambda fetched, total: progress.append((fetched, total)))
+    assert len(jobs) == 35
+    assert progress[-1][0] == 35
+
+
+def test_list_jobs_deduplicates(monkeypatch):
+    """Pages can have overlapping job IDs; list_jobs should deduplicate."""
+    page1 = [_make_entry(id="1"), _make_entry(id="2"), _make_entry(id="3")]
+    page2 = [_make_entry(id="3"), _make_entry(id="4")]  # id=3 is a duplicate
+
+    f = GoogleFetcher("")
+    post_calls = 0
+
+    def mock_get(*args, **kwargs):
+        return _mock_careers_page()
+
+    def mock_post(*args, **kwargs):
+        nonlocal post_calls
+        post_calls += 1
+        if post_calls == 1:
+            return _mock_batchexecute_response(page1, total=4)
+        if post_calls == 2:
+            return _mock_batchexecute_response(page2, total=4)
+        return _mock_batchexecute_response([], total=4)
+
+    monkeypatch.setattr(f.client, "get", mock_get)
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    jobs = f.list_jobs()
+    assert len(jobs) == 4
+    assert {j.id for j in jobs} == {"1", "2", "3", "4"}
+
+
+def test_list_jobs_unreliable_total(monkeypatch):
+    """Google reports a total that's lower than actual job count; should keep paginating."""
+    page1 = [_make_entry(id=str(i)) for i in range(20)]
+    page2 = [_make_entry(id=str(i)) for i in range(20, 40)]
+    page3 = [_make_entry(id=str(i)) for i in range(40, 50)]
+
+    f = GoogleFetcher("")
+    post_calls = 0
+
+    def mock_get(*args, **kwargs):
+        return _mock_careers_page()
+
+    def mock_post(*args, **kwargs):
+        nonlocal post_calls
+        post_calls += 1
+        if post_calls == 1:
+            return _mock_batchexecute_response(page1, total=25)
+        if post_calls == 2:
+            return _mock_batchexecute_response(page2, total=25)
+        if post_calls == 3:
+            return _mock_batchexecute_response(page3, total=25)
+        return _mock_batchexecute_response([], total=25)
+
+    monkeypatch.setattr(f.client, "get", mock_get)
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    jobs = f.list_jobs()
+    assert len(jobs) == 50
+
+
+# ---------------------------------------------------------------------------
+# fetch_job (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+def test_fetch_job_found(monkeypatch):
+    target = _make_entry(id="42", title="Target Role")
+    entries = [_make_entry(id="1"), target, _make_entry(id="99")]
+
+    f = GoogleFetcher("")
+
+    def mock_get(*args, **kwargs):
+        return _mock_careers_page()
+
+    def mock_post(*args, **kwargs):
+        return _mock_batchexecute_response(entries, total=3)
+
+    monkeypatch.setattr(f.client, "get", mock_get)
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    job = f.fetch_job("42")
+    assert job.id == "42"
+    assert job.title == "Target Role"
+
+
+def test_fetch_job_not_found(monkeypatch):
+    f = GoogleFetcher("")
+
+    def mock_get(*args, **kwargs):
+        return _mock_careers_page()
+
+    def mock_post(*args, **kwargs):
+        return _mock_batchexecute_response([], total=0)
+
+    monkeypatch.setattr(f.client, "get", mock_get)
+    monkeypatch.setattr(f.client, "post", mock_post)
+
+    with pytest.raises(ValueError, match="not found"):
+        f.fetch_job("nonexistent")


### PR DESCRIPTION
## Summary

- Reverse-engineered Google's internal batchexecute RPC protocol for their careers portal (`google.com/about/careers/applications`)
- No authentication/cookies required — public listings work with just `f.sid` and `bl` tokens scraped from the page HTML
- Full fetcher (descriptions in listing) — no enrichment phase needed
- Paginates until empty page, not by reported total (Google's count is unreliable — reports ~71, actual is ~3,800)
- Deduplicates across pages (Google returns overlapping results between pages)
- URL parser for `google.com/about/careers/applications/jobs/results/{job_id}`
- 27 unit tests covering token extraction, response parsing, field mapping, pagination, dedup, and unreliable-total edge case

## Files

- `src/jobbuddy/fetchers/google.py` — new fetcher
- `src/jobbuddy/fetchers/__init__.py` — registry entry
- `src/jobbuddy/url.py` — URL parser
- `tests/test_google.py` — tests

## Test plan

- [x] `uv run python -m pytest tests/test_google.py -v` — 27/27 pass
- [x] Live smoke test — fetches ~3,859 jobs with descriptions
- [ ] Register with `jsb companies-add Google --ats google --board google` after merge
- [ ] Run `jsb sync --company google` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)