### PR TITLE
infra: declare JOBBUDDY_AUTH_PROVIDER in function app settings

### DIFF
--- a/infrastructure/function_app.tf
+++ b/infrastructure/function_app.tf
@@ -139,6 +139,12 @@ resource "azurerm_function_app_flex_consumption" "mcp" {
     JOBBUDDY_OPENAI_AZURE_API_VERSION = "2024-12-01-preview"
     JOBBUDDY_STRIP_MODEL              = "gpt-5-nano"
     JOBBUDDY_EMBEDDING_MODEL          = "text-embedding-3-small"
+
+    # MCP authentication. Required by mcp_server.main()'s startup guard —
+    # the worker refuses to boot without it. Pinned to "entra" because the
+    # ENTRA_OAUTH_* settings above wire AzureProvider; if you ever swap to
+    # GitHubProvider, change this to "github" and replace those settings.
+    JOBBUDDY_AUTH_PROVIDER = "entra"
   }
 
   lifecycle {


### PR DESCRIPTION
## Summary

The MCP server's startup guard (added in #45 / commit 4c98d8d) refuses to boot when `JOBBUDDY_AUTH_PROVIDER` is unset. After #45 merged, prod cold-started into that exact failure (502 from Cloudflare → origin worker crash on `RuntimeError: JOBBUDDY_AUTH_PROVIDER must be set`).

Setting was added imperatively via `az functionapp config appsettings set` to unblock prod. This PR bakes it into Terraform so a future apply doesn't drift it back out, and so provisioning a fresh environment produces a working server on first deploy.

## Test plan

- [ ] `terraform plan` shows no diff against current Azure state (the imperative setting matches the declared value).
- [ ] `terraform apply` is a no-op — confirms parity.