### PR TITLE
talentbrew: per-company faucet URLs (acm filter + keyword passes)

### DIFF
--- a/src/jobbuddy/fetchers/talentbrew.py
+++ b/src/jobbuddy/fetchers/talentbrew.py
@@ -3,11 +3,18 @@
 TalentBrew career sites expose a search API at /search-jobs/results that returns
 JSON with HTML fragments. Job detail pages include JSON-LD structured data.
 
-Company registry fields:
+Company registry fields (stored in companies.config JSONB):
   - ats: "talentbrew"
   - board: not used (set to empty string)
   - tb_host: e.g. "jobs.intuit.com"
   - tb_tenant_id: numeric tenant ID from the URL path (e.g. 27595)
+  - tb_search_path: optional filter URL path+query (e.g. "/en/search-jobs?acm=12899").
+    When set, filter params are forwarded to the pagination endpoint. Defaults to
+    unfiltered behavior when omitted.
+  - tb_static_pagination: set true for tenants that require full-page GET with the
+    tenant ID in the path (e.g. "/search-jobs/185/{page}?acm=..."). Defaults false.
+  - tb_keyword_passes: list of keyword strings for additional fetches merged by job_id
+    (e.g. ["paint"]). Each keyword is fetched as an independent search pass.
 """
 
 import json
@@ -17,7 +24,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from jobbuddy.fetchers.base import ATSFetcher, JobList, ProgressCallback, RetryCallback
 from jobbuddy.models import Job, strip_html
@@ -85,10 +92,16 @@ class TalentBrewFetcher(ATSFetcher):
         *,
         tb_host: str = "",
         tb_tenant_id: int = 0,
+        tb_search_path: str = "",
+        tb_static_pagination: bool = False,
+        tb_keyword_passes: list[str] | None = None,
     ):
         super().__init__(board, name)
         self.tb_host = tb_host
         self.tb_tenant_id = tb_tenant_id
+        self.tb_search_path = tb_search_path
+        self.tb_static_pagination = tb_static_pagination
+        self.tb_keyword_passes = tb_keyword_passes or []
 
     def _require_config(self) -> None:
         if not self.tb_host or not self.tb_tenant_id:
@@ -100,13 +113,122 @@ class TalentBrewFetcher(ATSFetcher):
     def _base_url(self) -> str:
         return f"https://{self.tb_host}"
 
-    def _search_url(self, page: int) -> str:
+    def _acm_params(self) -> dict:
+        """Parse ACM (and other filter) params from tb_search_path query string.
+
+        Returns a flat {key: value} dict of the query params. Returns {} when
+        tb_search_path is empty, preserving unfiltered behavior.
+        """
+        if not self.tb_search_path:
+            return {}
+        parsed = urlparse(self.tb_search_path)
+        qs = parse_qs(parsed.query, keep_blank_values=False)
+        # parse_qs returns lists; flatten single-value params
+        return {k: v[0] if len(v) == 1 else ",".join(v) for k, v in qs.items()}
+
+    def _dynamic_url(self, page: int, extra_params: dict) -> str:
+        """Build the XHR JSON search endpoint URL for the given page."""
         params = {
             **_SEARCH_DEFAULTS,
+            **extra_params,
             "CurrentPage": str(page),
             "RecordsPerPage": str(_RECORDS_PER_PAGE),
         }
         return f"{self._base_url()}/search-jobs/results?{urlencode(params)}"
+
+    def _static_url(self, page: int, extra_params: dict) -> str:
+        """Build the static pagination URL for the given page.
+
+        Extracts the /search-jobs/{tenant_id}/ path prefix from tb_search_path,
+        then appends page number and query params.
+        """
+        parsed = urlparse(self.tb_search_path)
+        # Path is like /search-jobs/185/1 — strip the trailing page number
+        path_parts = parsed.path.rstrip("/").rsplit("/", 1)
+        base_path = path_parts[0]  # e.g. /search-jobs/185
+        query = urlencode(extra_params) if extra_params else ""
+        url = f"{self._base_url()}{base_path}/{page}"
+        if query:
+            url = f"{url}?{query}"
+        return url
+
+    def _fetch_all_pages(
+        self,
+        extra_params: dict,
+        *,
+        on_progress: ProgressCallback | None,
+        on_retry: RetryCallback | None,
+    ) -> list[Job]:
+        """Fetch all pages using either dynamic or static mode.
+
+        Returns a list of all jobs across all pages. Fires on_progress after
+        each page fetch. Uses ThreadPoolExecutor for pages 2+.
+        """
+        if self.tb_static_pagination:
+            url1 = self._static_url(1, extra_params)
+            resp = self._retry_request(
+                lambda: self.client.get(url1),
+                on_retry=on_retry,
+            )
+            resp.raise_for_status()
+            jobs, total = self._parse_results_html(resp.text)
+        else:
+            url1 = self._dynamic_url(1, extra_params)
+            resp = self._retry_request(
+                lambda: self.client.get(
+                    url1,
+                    headers={"X-Requested-With": "XMLHttpRequest"},
+                ),
+                on_retry=on_retry,
+            )
+            resp.raise_for_status()
+            jobs, total = self._parse_results_html(resp.json().get("results", ""))
+
+        if on_progress:
+            on_progress(len(jobs), total)
+
+        if total <= _RECORDS_PER_PAGE:
+            return jobs
+
+        total_pages = (total + _RECORDS_PER_PAGE - 1) // _RECORDS_PER_PAGE
+        remaining_pages = list(range(2, total_pages + 1))
+        lock = threading.Lock()
+
+        def _fetch_page(page: int) -> list[Job]:
+            if self.tb_static_pagination:
+                url = self._static_url(page, extra_params)
+                page_resp = self._retry_request(
+                    lambda u=url: self.client.get(u),
+                    on_retry=on_retry,
+                )
+                page_resp.raise_for_status()
+                page_jobs, _ = self._parse_results_html(page_resp.text)
+            else:
+                url = self._dynamic_url(page, extra_params)
+                page_resp = self._retry_request(
+                    lambda u=url: self.client.get(
+                        u,
+                        headers={"X-Requested-With": "XMLHttpRequest"},
+                    ),
+                    on_retry=on_retry,
+                )
+                page_resp.raise_for_status()
+                page_jobs, _ = self._parse_results_html(
+                    page_resp.json().get("results", "")
+                )
+            return page_jobs
+
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = {executor.submit(_fetch_page, p): p for p in remaining_pages}
+            for future in as_completed(futures):
+                page_jobs = future.result()
+                with lock:
+                    jobs.extend(page_jobs)
+                    current = len(jobs)
+                if on_progress:
+                    on_progress(current, total)
+
+        return jobs
 
     def _parse_results_html(self, html: str) -> tuple[list[Job], int]:
         """Parse the results HTML fragment. Returns (jobs, total_results).
@@ -190,51 +312,25 @@ class TalentBrewFetcher(ATSFetcher):
     ) -> JobList:
         self._require_config()
 
-        # Fetch page 1 to learn total
-        resp = self._retry_request(
-            lambda: self.client.get(
-                self._search_url(1),
-                headers={"X-Requested-With": "XMLHttpRequest"},
-            ),
-            on_retry=on_retry,
-        )
-        resp.raise_for_status()
-        data = resp.json()
+        # Main pass: fetch with ACM filter params (or no filter if tb_search_path is empty)
+        acm = self._acm_params()
+        jobs = self._fetch_all_pages(acm, on_progress=on_progress, on_retry=on_retry)
 
-        jobs, total = self._parse_results_html(data.get("results", ""))
-        if on_progress:
-            on_progress(len(jobs), total)
-
-        if total <= _RECORDS_PER_PAGE:
-            return jobs
-
-        total_pages = (total + _RECORDS_PER_PAGE - 1) // _RECORDS_PER_PAGE
-        remaining_pages = list(range(2, total_pages + 1))
-
-        lock = threading.Lock()
-
-        def _fetch_page(page: int) -> list[Job]:
-            page_resp = self._retry_request(
-                lambda p=page: self.client.get(
-                    self._search_url(p),
-                    headers={"X-Requested-With": "XMLHttpRequest"},
-                ),
-                on_retry=on_retry,
-            )
-            page_resp.raise_for_status()
-            page_data = page_resp.json()
-            page_jobs, _ = self._parse_results_html(page_data.get("results", ""))
-            return page_jobs
-
-        with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = {executor.submit(_fetch_page, p): p for p in remaining_pages}
-            for future in as_completed(futures):
-                page_jobs = future.result()
-                with lock:
-                    jobs.extend(page_jobs)
-                    current = len(jobs)
-                if on_progress:
-                    on_progress(current, total)
+        # Keyword passes: additional fetches merged/deduped by job id
+        if self.tb_keyword_passes:
+            seen_ids = {j.id for j in jobs}
+            for keyword in self.tb_keyword_passes:
+                if self.tb_static_pagination:
+                    kw_params = {"k": keyword}
+                else:
+                    kw_params = {"Keywords": keyword}
+                kw_jobs = self._fetch_all_pages(
+                    kw_params, on_progress=None, on_retry=on_retry
+                )
+                for job in kw_jobs:
+                    if job.id not in seen_ids:
+                        jobs.append(job)
+                        seen_ids.add(job.id)
 
         return jobs
 

--- a/src/jobbuddy/migrations/016_talentbrew_faucets.sql
+++ b/src/jobbuddy/migrations/016_talentbrew_faucets.sql
@@ -35,6 +35,3 @@ UPDATE companies
 UPDATE companies
     SET config = '{"tb_host": "jobs.disneycareers.com", "tb_tenant_id": 391, "tb_search_path": "/search-jobs/391/1?acm=26715,21579,8221776,8221696", "tb_static_pagination": true}'::jsonb
     WHERE slug = 'disney';
-
--- Remove company with no relevant open roles
-DELETE FROM companies WHERE slug = 'wegmans';

--- a/src/jobbuddy/migrations/016_talentbrew_faucets.sql
+++ b/src/jobbuddy/migrations/016_talentbrew_faucets.sql
@@ -1,0 +1,40 @@
+-- Narrow TalentBrew fetches to relevant job categories via per-company filter config.
+-- Each UPDATE sets the full config for that company (tb_host + tb_tenant_id + filter fields).
+
+-- Pharmacy / retail jobs only
+UPDATE companies
+    SET config = '{"tb_host": "jobs.walgreens.com", "tb_tenant_id": 1242, "tb_search_path": "/en/search-jobs?acm=12899"}'::jsonb
+    WHERE slug = 'walgreens';
+
+-- Finance / technology / operations roles
+UPDATE companies
+    SET config = '{"tb_host": "jobs.citi.com", "tb_tenant_id": 287, "tb_search_path": "/en/search-jobs?acm=19627,8295232,8644128"}'::jsonb
+    WHERE slug = 'citi';
+
+-- Engineering / manufacturing categories; static pagination + keyword pass for specialty trades
+UPDATE companies
+    SET config = '{"tb_host": "jobs.boeing.com", "tb_tenant_id": 185, "tb_search_path": "/search-jobs/185/1?acm=11125,2630,4744,18389,2644", "tb_static_pagination": true, "tb_keyword_passes": ["paint"]}'::jsonb
+    WHERE slug = 'boeing';
+
+-- Technology / network operations categories; static pagination required
+UPDATE companies
+    SET config = '{"tb_host": "jobs.spectrum.com", "tb_tenant_id": 4673, "tb_search_path": "/search-jobs/4673/1?acm=26210,63667,81595,81694,68006,81729,81593,81594", "tb_static_pagination": true}'::jsonb
+    WHERE slug = 'spectrum';
+
+-- Technology / product / engineering categories
+UPDATE companies
+    SET config = '{"tb_host": "jobs.comcast.com", "tb_tenant_id": 45483, "tb_search_path": "/en/search-jobs?acm=8795856,8856496,8795824,8796032,8795920,8795888,8707664,8707408"}'::jsonb
+    WHERE slug = 'comcast';
+
+-- Defense electronics engineering categories + specialty coatings keyword pass
+UPDATE companies
+    SET config = '{"tb_host": "careers.l3harris.com", "tb_tenant_id": 4832, "tb_search_path": "/en/search-jobs?acm=61370,65926,61407", "tb_keyword_passes": ["coatings"]}'::jsonb
+    WHERE slug = 'l3harris';
+
+-- Entertainment / theme park operations categories; static pagination required
+UPDATE companies
+    SET config = '{"tb_host": "jobs.disneycareers.com", "tb_tenant_id": 391, "tb_search_path": "/search-jobs/391/1?acm=26715,21579,8221776,8221696", "tb_static_pagination": true}'::jsonb
+    WHERE slug = 'disney';
+
+-- Remove company with no relevant open roles
+DELETE FROM companies WHERE slug = 'wegmans';

--- a/tests/test_talentbrew.py
+++ b/tests/test_talentbrew.py
@@ -1,10 +1,11 @@
-"""Tests for the TalentBrew fetcher's detail-page parser.
+"""Tests for the TalentBrew fetcher's detail-page parser and list_jobs filtering.
 
-Focuses on JSON-LD extraction of description and datePosted, including the
-non-zero-padded date format real Walgreens pages return (e.g. "2026-4-25").
+Covers JSON-LD extraction, per-company ACM filter config, static pagination,
+and keyword-pass deduplication.
 """
 
 from datetime import date
+from unittest.mock import MagicMock, patch
 
 from jobbuddy.fetchers.talentbrew import TalentBrewFetcher
 
@@ -138,3 +139,169 @@ class TestEnrichmentFills:
         description."""
         assert "published_at" in TalentBrewFetcher.enrichment_fills
         assert "description" in TalentBrewFetcher.enrichment_fills
+
+
+# ---------------------------------------------------------------------------
+# Helpers for list_jobs filtering tests
+# ---------------------------------------------------------------------------
+
+def _dynamic_html_fragment(job_id: str, title: str, total: int) -> str:
+    """Minimal HTML fragment for dynamic (XHR JSON) mode."""
+    return (
+        f'<div data-total-results="{total}">'
+        f'<ul><li><a href="/en/job/test-{job_id}" data-job-id="{job_id}" '
+        f'data-title="{title}"></a></li></ul></div>'
+    )
+
+
+def _static_html_page(job_id: str, title: str, total: int) -> str:
+    """Minimal full HTML for static pagination mode."""
+    return (
+        f'<html><body data-total-results="{total}">'
+        f'<ul><li><a href="/en/job/test-{job_id}" data-job-id="{job_id}" '
+        f'data-title="{title}"></a></li></ul></body></html>'
+    )
+
+
+def _mock_dynamic_response(html_fragment: str) -> MagicMock:
+    """Mock httpx response for dynamic (XHR JSON) mode: .json()['results'] = html."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"results": html_fragment}
+    resp.text = html_fragment
+    return resp
+
+
+def _mock_static_response(html: str) -> MagicMock:
+    """Mock httpx response for static pagination mode: .text = full html."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.side_effect = ValueError("static mode does not return JSON")
+    resp.text = html
+    return resp
+
+
+class TestListJobsFiltering:
+    def test_default_no_filter_uses_results_endpoint(self):
+        """When tb_search_path is empty, URL hits /search-jobs/results without acm param."""
+        fetcher = TalentBrewFetcher(
+            board="walgreens",
+            tb_host="jobs.walgreens.com",
+            tb_tenant_id=1242,
+            tb_search_path="",
+        )
+        html = _dynamic_html_fragment("100", "Engineer", 1)
+        mock_resp = _mock_dynamic_response(html)
+
+        captured_urls = []
+
+        def fake_get(url, **kwargs):
+            captured_urls.append(url)
+            return mock_resp
+
+        with patch.object(fetcher.client, "get", side_effect=fake_get):
+            jobs = fetcher.list_jobs()
+
+        assert len(jobs) == 1
+        assert jobs[0].id == "100"
+        assert all("/search-jobs/results" in u for u in captured_urls)
+        assert not any("acm" in u for u in captured_urls)
+
+    def test_dynamic_acm_filter_in_url(self):
+        """When tb_search_path has acm param, URL includes acm=12899."""
+        fetcher = TalentBrewFetcher(
+            board="walgreens",
+            tb_host="jobs.walgreens.com",
+            tb_tenant_id=1242,
+            tb_search_path="/en/search-jobs?acm=12899",
+        )
+        html = _dynamic_html_fragment("200", "Pharmacist", 1)
+        mock_resp = _mock_dynamic_response(html)
+
+        captured_urls = []
+
+        def fake_get(url, **kwargs):
+            captured_urls.append(url)
+            return mock_resp
+
+        with patch.object(fetcher.client, "get", side_effect=fake_get):
+            jobs = fetcher.list_jobs()
+
+        assert len(jobs) == 1
+        assert any("acm=12899" in u for u in captured_urls)
+        assert all("/search-jobs/results" in u for u in captured_urls)
+
+    def test_static_pagination_builds_correct_url(self):
+        """When tb_static_pagination=True, page 1 URL is /search-jobs/185/1?acm=11125."""
+        fetcher = TalentBrewFetcher(
+            board="boeing",
+            tb_host="jobs.boeing.com",
+            tb_tenant_id=185,
+            tb_search_path="/search-jobs/185/1?acm=11125",
+            tb_static_pagination=True,
+        )
+        html = _static_html_page("300", "Engineer", 1)
+        mock_resp = _mock_static_response(html)
+
+        captured_urls = []
+
+        def fake_get(url, **kwargs):
+            captured_urls.append(url)
+            return mock_resp
+
+        with patch.object(fetcher.client, "get", side_effect=fake_get):
+            jobs = fetcher.list_jobs()
+
+        assert len(jobs) == 1
+        assert any("/search-jobs/185/1" in u for u in captured_urls)
+        assert any("acm=11125" in u for u in captured_urls)
+        # Must NOT use the dynamic /search-jobs/results endpoint
+        assert not any("/search-jobs/results" in u for u in captured_urls)
+
+    def test_keyword_passes_merged_and_deduped(self):
+        """Keyword passes merge into main list, deduplicated by job.id."""
+        fetcher = TalentBrewFetcher(
+            board="boeing",
+            tb_host="jobs.boeing.com",
+            tb_tenant_id=185,
+            tb_search_path="/search-jobs/185/1?acm=11125",
+            tb_static_pagination=True,
+            tb_keyword_passes=["paint"],
+        )
+        # Main pass: jobs 301, 302 (total=2, fits one page)
+        main_html = (
+            '<div data-total-results="2">'
+            '<ul>'
+            '<li><a href="/en/job/test-301" data-job-id="301" data-title="Job A"></a></li>'
+            '<li><a href="/en/job/test-302" data-job-id="302" data-title="Job B"></a></li>'
+            '</ul></div>'
+        )
+        # Keyword pass: jobs 302 (overlap), 303 (new)
+        kw_html = (
+            '<div data-total-results="2">'
+            '<ul>'
+            '<li><a href="/en/job/test-302" data-job-id="302" data-title="Job B"></a></li>'
+            '<li><a href="/en/job/test-303" data-job-id="303" data-title="Job C"></a></li>'
+            '</ul></div>'
+        )
+
+        call_count = [0]
+
+        def fake_get(url, **kwargs):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.side_effect = ValueError("static mode")
+            call_count[0] += 1
+            # First call = main pass page 1; second call = keyword pass page 1
+            if call_count[0] == 1:
+                resp.text = main_html
+            else:
+                resp.text = kw_html
+            return resp
+
+        with patch.object(fetcher.client, "get", side_effect=fake_get):
+            jobs = fetcher.list_jobs()
+
+        job_ids = {j.id for j in jobs}
+        assert job_ids == {"301", "302", "303"}
+        assert len(jobs) == 3


### PR DESCRIPTION
## Summary

- Adds `tb_search_path`, `tb_static_pagination`, and `tb_keyword_passes` config fields to `TalentBrewFetcher`
- When `tb_search_path` is set, ACM category filter params are forwarded to the pagination endpoint — narrows fetches from the full unfiltered job list to only relevant categories
- `tb_static_pagination: true` switches pagination to full-page GET with the tenant ID in the URL path (required for Boeing, Disney, Spectrum)
- `tb_keyword_passes` runs independent keyword searches and merges results deduplicated by job ID (used for specialty trades roles not captured by any category filter)
- Migration 016 updates config for walgreens, citi, boeing, spectrum, comcast, l3harris, and disney; removes wegmans

## Why

Walgreens alone was fetching ~17,420 jobs unfiltered; the tech-profile faucet narrows it to ~14. Across these 8 tenants the combined fetch volume drops from ~28k+ to ~3k jobs.

## Test plan

- [ ] 15 TalentBrew unit tests pass (4 new in `TestListJobsFiltering`)
- [ ] Full suite green (470 tests)
- [ ] Apply migration: `jsb migrate`
- [ ] Spot-check after first sync: walgreens active jobs in DB drops to ~14; wegmans gone; boeing shows painter-trades jobs from keyword pass

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)