### PR TITLE
companies: phenom + eightfold faucet filters

### DIFF
--- a/src/jobbuddy/migrations/017_phenom_eightfold_faucets.sql
+++ b/src/jobbuddy/migrations/017_phenom_eightfold_faucets.sql
@@ -1,0 +1,59 @@
+-- Category faucets for 4 Phenom tenants and 1 Eightfold tenant.
+-- Each UPDATE uses jsonb merge (||) or jsonb_set to add filter keys
+-- without clobbering existing config keys (locale, country, careers_url, etc.).
+
+-- bae-systems (Phenom): tech/engineering + trades/paint bucket
+UPDATE companies SET config = config || jsonb_build_object(
+  'selected_fields', jsonb_build_object(
+    'category', jsonb_build_array(
+      'Engineering & Technology',
+      'Project & Program Management',
+      'Intelligence',
+      'Manufacturing & Maintenance'
+    )
+  )
+) WHERE slug = 'bae-systems';
+
+-- rtx (Phenom): tech/engineering + trades/paint bucket
+UPDATE companies SET config = config || jsonb_build_object(
+  'selected_fields', jsonb_build_object(
+    'category', jsonb_build_array(
+      'Engineering',
+      'Digital Technology',
+      'Operations'
+    )
+  )
+) WHERE slug = 'rtx';
+
+-- us-bank (Phenom): already has selected_fields.country; add category
+-- using jsonb_set to merge into the existing selected_fields object
+UPDATE companies SET config = jsonb_set(
+  config,
+  '{selected_fields,category}',
+  '["Technology & Digital"]'::jsonb
+) WHERE slug = 'us-bank';
+
+-- ge-aerospace (Phenom): tech/engineering + trades/paint bucket
+UPDATE companies SET config = config || jsonb_build_object(
+  'selected_fields', jsonb_build_object(
+    'category', jsonb_build_array(
+      'Engineering / Technology',
+      'Digital Technology / IT',
+      'Manufacturing & Logistics'
+    )
+  )
+) WHERE slug = 'ge-aerospace';
+
+-- northropgrumman (Eightfold): tech + manufacturing bucket
+-- filter_department passed as repeated query params by httpx QueryParams
+UPDATE companies SET config = config || jsonb_build_object(
+  'default_filters', jsonb_build_object(
+    'filter_department', jsonb_build_array(
+      'Software Engineering',
+      'Information Technology',
+      'Data & Analytics',
+      'Product & Design',
+      'Manufacturing'
+    )
+  )
+) WHERE slug = 'northropgrumman';


### PR DESCRIPTION
## Summary

Adds migration `017_phenom_eightfold_faucets.sql` that sets category-level fetch filters on 5 large-tenant companies, cutting distill cost and search noise from roles outside the two target profiles (tech/engineering and industrial-trades/paint-coatings).

Parallel to PR #51 (issue #50), which covers TalentBrew tenants. No fetcher code changes — both Phenom (`selected_fields`) and Eightfold (`default_filters`) already support these filter dicts.

## What's filtered

| Company | Platform | Filter key | Retained / Total | Cut |
|---|---|---|---|---|
| bae-systems | Phenom | `selected_fields.category` | 1,389 / 1,673 | ~17% |
| rtx | Phenom | `selected_fields.category` | 3,180 / 4,396 | ~28% |
| us-bank | Phenom | `selected_fields.category` (added to existing `country` filter) | 75 / 1,169 | ~94% |
| ge-aerospace | Phenom | `selected_fields.category` | 533 / 729 | ~27% |
| northropgrumman | Eightfold | `default_filters.filter_department` | ~998 / 2,455 | ~59% |

Across these 5 tenants the net reduction is roughly **860 fewer new jobs/wk**, translating to approximately **$60–90/yr** saved at current distill rates (~$0.0018/job).

### Category selections

**bae-systems**: Engineering & Technology, Project & Program Management, Intelligence, Manufacturing & Maintenance — the last bucket contains verified painter/coatings titles (Marine Sandblaster/Painter, Paint and Coatings Specialist, Finish Shop Operator-Painter).

**rtx**: Engineering, Digital Technology, Operations — Operations contains 18 paint + 19 coatings + 61 surface hits (Wheel Paint Operator, Painter I/II, Sermetel Finish Technician, Surface Prep Technician).

**us-bank**: Technology & Digital only. Sitewide `keywords="paint"` returned 0 hits so no trades-profile bucket exists at this tenant; Corporate Functions & Risk was investigated and rejected (0 engineer-keyword hits — pure compliance/legal/marketing noise).

**ge-aerospace**: Engineering / Technology, Digital Technology / IT, Manufacturing & Logistics — Manufacturing & Logistics contains Painter 2, Metal Spray Operator, Sermetel Painting Finish Technician, Surface Prep Technician II.

**northropgrumman**: Software Engineering (513), Information Technology (99), Data & Analytics (27), Product & Design (134), Manufacturing (225). "Engineering (Non-IT)" (990) was excluded — mostly aerospace structural/RF/systems roles requiring active security clearance, low software-adjacent signal. Manufacturing intersection with paint = 10 hits (Aircraft Painter, Paint Technician 4, Aircraft Low Observable Mechanic / stealth-coating work).

## Migration approach

Uses jsonb merge (`config || jsonb_build_object(...)`) for rows without an existing `selected_fields`, and `jsonb_set` for us-bank (which already has `selected_fields.country`) to add the `category` key without clobbering the existing country filter.

## Verification

- Migration applied cleanly: `017_phenom_eightfold_faucets.sql` applied in 1 step, no errors.
- Full test suite: **466 passed, 0 failures**.
- Prod DB read-only spot-check confirmed correct JSON shape on all 5 rows, including us-bank preserving its existing `locale`, `country`, `careers_url`, and `selected_fields.country`.

**Note on Northrop Grumman Eightfold multi-value params**: `httpx.QueryParams({'filter_department': ['a', 'b']})` serializes as repeated keys (`?filter_department=a&filter_department=b`), which is the correct form for the Eightfold API. A live pagination smoke-test against the NG endpoint was not run in this PR — if multi-value params fail end-to-end, document and iterate; no fetcher changes are in scope here.

Closes #50 (partial — Phenom + Eightfold tenants; TalentBrew tenants in PR #51).