### PR TITLE
fetchers: add last_listing_update column for ATSes that surface a freshness signal

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,14 @@ Two date columns capture different ATS-side semantics:
   distinct field exists. Updates on every sync via `GREATEST()`, so a
   newer ATS-side timestamp overrides the stored value while a NULL never
   clobbers an existing one.
+- `effective_date` — generated `COALESCE(last_listing_update,
+  published_at)`. Drives `posted_after` filtering and recency ordering in
+  `query_jobs` / `search_jobs_fts` / `survey_jobs_by_company` so "posted
+  in the last 30 days" surfaces ATS-fresh listings rather than only those
+  whose first-publish date happens to be recent. `published_at` is still
+  what surfaces in `CompactJob.published_at` and what users see on the
+  detail page; `last_listing_update` is exposed alongside it as
+  `updated` so the LLM can see the divergence.
 
 Per-fetcher mapping for `last_listing_update`:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,9 @@ worker threads in the sync pipeline each create their own instance.
 
 ```sql
 jobs             -- SERIAL PK (surrogate), UNIQUE(company_slug, job_id)
-                 --   title, location, url, published_at, salary, team,
+                 --   title, location, url, published_at,
+                 --   last_listing_update (per-fetcher freshness signal — see
+                 --                        "Date columns" below), salary, team,
                  --   department, description (raw, never returned by MCP),
                  --   short_jd, description_normalized (distill outputs),
                  --   ats_metadata (JSONB), last_seen,
@@ -73,6 +75,34 @@ sees the raw `description` change on an existing job, it nulls
 `short_jd` / `description_normalized` so the distill phase picks the
 row up again on the next pass — replaces the content_hash invalidation
 path that the embedding pipeline used.
+
+### Date columns
+
+Two date columns capture different ATS-side semantics:
+
+- `published_at` — what the ATS reports as the listing's publish date.
+  Source field varies: Greenhouse `first_published`, Lever `createdAt`,
+  Ashby `publishedAt`, Apple `postDateInGMT`, Eightfold `postedTs`,
+  Avature sitemap `<lastmod>`, etc. Pure-insert: fixed at first sync.
+- `last_listing_update` — what the ATS reports about freshness, where a
+  distinct field exists. Updates on every sync via `GREATEST()`, so a
+  newer ATS-side timestamp overrides the stored value while a NULL never
+  clobbers an existing one.
+
+Per-fetcher mapping for `last_listing_update`:
+
+| Fetcher       | Source field                                              |
+|---------------|-----------------------------------------------------------|
+| greenhouse    | `updated_at` (board API)                                  |
+| amazon        | `updatedDate` (search hit fields)                         |
+| eightfold_v2  | `t_update` (epoch seconds on each position)               |
+| jibe          | `update_date`, falling back to `meta_data.icims.date_updated` |
+| avature       | sitemap `<lastmod>` (also feeds `published_at` — Avature has no separate first-publish field) |
+| (others)      | NULL — public API exposes only one date                   |
+
+Live probes against every wired ATS confirm the table above is exhaustive
+for ATSes that publicly expose a separate "last updated" timestamp. See
+issue #53 for the per-platform investigation.
 
 ### Soft-Delete
 

--- a/src/jobbuddy/core.py
+++ b/src/jobbuddy/core.py
@@ -31,6 +31,11 @@ class JobRow(BaseModel):
     title: str
     location: str | None = None
     posted: str | None = None
+    # ATS-side freshness signal (greenhouse/amazon/eightfold_v2/jibe/avature
+    # populate this; others leave it None). When the LLM sees `updated` and
+    # `posted` diverge sharply, that's the cue that an old `posted` date
+    # belongs to an actively-republished listing rather than a stale req.
+    updated: str | None = None
     snippet: str | None = None
     url: str | None = None
     salary: str | None = None
@@ -68,6 +73,11 @@ def _to_jobrow(row: dict) -> JobRow:
         pa = row.get("published_at")
         posted = pa.isoformat() if hasattr(pa, "isoformat") else (pa or None)
 
+    updated = row.get("updated")
+    if updated is None:
+        llu = row.get("last_listing_update")
+        updated = llu.isoformat() if hasattr(llu, "isoformat") else (llu or None)
+
     snippet = row.get("snippet")
     if snippet is None:
         short_jd = row.get("short_jd")
@@ -81,6 +91,7 @@ def _to_jobrow(row: dict) -> JobRow:
         title=row["title"],
         location=row.get("location") or None,
         posted=posted,
+        updated=updated,
         snippet=snippet,
         url=row.get("url") or None,
         salary=row.get("salary"),

--- a/src/jobbuddy/fetchers/amazon.py
+++ b/src/jobbuddy/fetchers/amazon.py
@@ -144,6 +144,7 @@ class AmazonFetcher(ATSFetcher):
             url=f"https://www.amazon.jobs/en/jobs/{job_id}/{slug}",
             apply_url=url_next_step or f"https://account.amazon.jobs/jobs/{job_id}/apply",
             published_at=_parse_epoch(_first(fields.get("createdDate"))),
+            last_listing_update=_parse_epoch(_first(fields.get("updatedDate"))),
             department=category,
             team=job_family,
             description=description,

--- a/src/jobbuddy/fetchers/avature.py
+++ b/src/jobbuddy/fetchers/avature.py
@@ -239,10 +239,18 @@ class AvatureFetcher(ATSFetcher):
         # per-JobDetail <lastmod> values. Best-effort: a sitemap fetch
         # failure leaves published_at NULL and the upsert's scrape-date
         # fallback handles it.
+        #
+        # `lastmod` is a regenerated-on-edit signal, so it's also the most
+        # honest value for `last_listing_update` — Avature has no separate
+        # "first published" field exposed publicly, so the same date plays
+        # both roles for this ATS.
         sitemap_dates = self._fetch_sitemap_dates(on_retry=on_retry)
         if sitemap_dates:
             jobs = [
-                j.model_copy(update={"published_at": sitemap_dates[j.id]})
+                j.model_copy(update={
+                    "published_at": sitemap_dates[j.id],
+                    "last_listing_update": sitemap_dates[j.id],
+                })
                 if j.id in sitemap_dates else j
                 for j in jobs
             ]

--- a/src/jobbuddy/fetchers/eightfold_v2.py
+++ b/src/jobbuddy/fetchers/eightfold_v2.py
@@ -70,14 +70,21 @@ class EightfoldV2Fetcher(ATSFetcher):
                 meta[key] = val[0] if isinstance(val, list) and len(val) == 1 else val
         return meta or None
 
+    @staticmethod
+    def _epoch_to_date(value):
+        if not value:
+            return None
+        try:
+            return datetime.fromtimestamp(value, tz=timezone.utc).date()
+        except (ValueError, OSError, OverflowError):
+            return None
+
     def _position_to_job(self, pos: dict) -> Job:
         """Map a position object from v2 search results to a Job."""
         pos_id = str(pos["id"])
         locations = pos.get("standardizedLocations") or pos.get("locations") or []
-        posted_ts = pos.get("t_create")
-        published_at = None
-        if posted_ts:
-            published_at = datetime.fromtimestamp(posted_ts, tz=timezone.utc).date()
+        published_at = self._epoch_to_date(pos.get("t_create"))
+        updated_at = self._epoch_to_date(pos.get("t_update"))
 
         url = f"{self.base_url}/careers/job/{pos_id}"
         return Job(
@@ -87,6 +94,7 @@ class EightfoldV2Fetcher(ATSFetcher):
             url=url,
             apply_url=url,
             published_at=published_at,
+            last_listing_update=updated_at,
             department=pos.get("department"),
             ats_metadata=self._extract_metadata(pos),
         )
@@ -151,10 +159,8 @@ class EightfoldV2Fetcher(ATSFetcher):
             raise ValueError(f"Position {job_id} not found.")
 
         locations = data.get("standardizedLocations") or data.get("locations") or []
-        posted_ts = data.get("t_create")
-        published_at = None
-        if posted_ts:
-            published_at = datetime.fromtimestamp(posted_ts, tz=timezone.utc).date()
+        published_at = self._epoch_to_date(data.get("t_create"))
+        updated_at = self._epoch_to_date(data.get("t_update"))
 
         url = f"{self.base_url}/careers/job/{job_id}"
         description = data.get("job_description", "")
@@ -168,6 +174,7 @@ class EightfoldV2Fetcher(ATSFetcher):
             url=url,
             apply_url=url,
             published_at=published_at,
+            last_listing_update=updated_at,
             department=data.get("department"),
             description=description or None,
             ats_metadata=self._extract_metadata(data),

--- a/src/jobbuddy/fetchers/greenhouse.py
+++ b/src/jobbuddy/fetchers/greenhouse.py
@@ -29,6 +29,10 @@ class GreenhouseFetcher(ATSFetcher):
             if published:
                 published = published[:10]
 
+            updated = j.get("updated_at")
+            if updated:
+                updated = updated[:10]
+
             department = None
             for m in j.get("departments", []):
                 department = m.get("name")
@@ -45,6 +49,7 @@ class GreenhouseFetcher(ATSFetcher):
                     url=j.get("absolute_url", ""),
                     apply_url=j.get("absolute_url", ""),
                     published_at=published,
+                    last_listing_update=updated,
                     department=department,
                     team=department,
                     description=description,

--- a/src/jobbuddy/fetchers/jibe.py
+++ b/src/jobbuddy/fetchers/jibe.py
@@ -89,6 +89,16 @@ class JibeFetcher(ATSFetcher):
         categories = data.get("categories", [])
         department = categories[0]["name"] if categories else None
 
+        # Jibe payloads carry both `posted_date` (first-listed) and
+        # `update_date` (last touch in iCIMS). Fall back to the iCIMS
+        # nested `meta_data.icims.date_updated` when `update_date` is
+        # absent on older payloads.
+        update_date = data.get("update_date")
+        if not update_date:
+            meta = data.get("meta_data") or {}
+            icims = meta.get("icims") or {}
+            update_date = icims.get("date_updated")
+
         return Job(
             id=slug,
             title=data.get("title", ""),
@@ -96,6 +106,7 @@ class JibeFetcher(ATSFetcher):
             url=self._job_url(slug),
             apply_url=data.get("apply_url", self._job_url(slug)),
             published_at=_parse_date(data.get("posted_date")),
+            last_listing_update=_parse_date(update_date),
             department=department,
             salary=salary,
             description=description,

--- a/src/jobbuddy/migrations/018_jobs_last_listing_update.sql
+++ b/src/jobbuddy/migrations/018_jobs_last_listing_update.sql
@@ -1,0 +1,20 @@
+-- Issue #53: per-fetcher last_listing_update.
+--
+-- Adds a second date column for ATSes that publicly expose a "last
+-- updated" timestamp distinct from the original first-publish date.
+-- See docs/architecture.md for the per-fetcher mapping.
+--
+-- Semantics:
+--   published_at        -- what the ATS reports as the listing's publish
+--                          date (first_published / createdAt / postedAt /
+--                          sitemap lastmod, depending on platform).
+--   last_listing_update -- what the ATS reports about freshness, where a
+--                          distinct field exists. NULL for ATSes whose
+--                          public API only exposes one date.
+--
+-- The store upsert preserves the latest non-NULL value via GREATEST() so a
+-- subsequent sync that observes a newer ATS-side update overwrites an
+-- older value, while a NULL from a fetcher that doesn't surface this
+-- field never clobbers an existing value.
+
+ALTER TABLE jobs ADD COLUMN last_listing_update DATE NULL;

--- a/src/jobbuddy/migrations/019_jobs_effective_date.sql
+++ b/src/jobbuddy/migrations/019_jobs_effective_date.sql
@@ -1,0 +1,30 @@
+-- Issue #58: derived freshness date for filtering and ranking.
+--
+-- effective_date is COALESCE(last_listing_update, published_at) materialized
+-- as a STORED generated column so search/ranking can index against it
+-- without re-evaluating the COALESCE per row.
+--
+-- Why a generated column instead of inline COALESCE in queries:
+--   1. We can index it. Sorting and `posted_after` filtering both want a
+--      sortable date — the existing idx_jobs_published_pagination is on
+--      published_at, which becomes the wrong key once the LLM expects
+--      freshness semantics.
+--   2. One source of truth. Every read path that wants "last sign of life"
+--      reads the same column instead of re-deriving COALESCE, which drifts.
+--   3. Backward compatibility. Rows whose fetcher doesn't surface
+--      last_listing_update keep effective_date = published_at, so existing
+--      reports/queries against published_at still match the same dates
+--      they did before.
+--
+-- published_at is NOT NULL (migration 014), so effective_date is also
+-- NOT NULL — no NULLS LAST needed in ORDER BY clauses.
+
+ALTER TABLE jobs
+  ADD COLUMN effective_date DATE
+  GENERATED ALWAYS AS (COALESCE(last_listing_update, published_at)) STORED;
+
+-- Replaces idx_jobs_published_pagination as the workhorse for paginated
+-- recency queries. Old index stays in place — some scripts/reports still
+-- want strict publish-date ordering.
+CREATE INDEX idx_jobs_effective_pagination
+  ON jobs (effective_date DESC, company_slug, job_id);

--- a/src/jobbuddy/models.py
+++ b/src/jobbuddy/models.py
@@ -70,6 +70,7 @@ class Job(BaseModel):
     url: str
     apply_url: str
     published_at: PublishedAt = None
+    last_listing_update: PublishedAt = None
     department: str | None = None
     team: str | None = None
     salary: str | None = None

--- a/src/jobbuddy/models.py
+++ b/src/jobbuddy/models.py
@@ -200,6 +200,13 @@ class CompactJob(BaseModel):
     apply_url: str | None = None
     id: str
     published_at: PublishedAt = None
+    # ATS-side freshness signal where the platform exposes one (greenhouse,
+    # amazon, eightfold_v2, jibe, avature). NULL for ATSes whose public API
+    # only surfaces a single date — the LLM should treat absence as
+    # "freshness unknown," not "stale." Critical for disambiguating
+    # year+-old `published_at` values that have actually been touched in
+    # the ATS within the last week (see issue #53).
+    last_listing_update: PublishedAt = None
     department: str | None = None
     team: str | None = None
     salary: str | None = None
@@ -240,6 +247,7 @@ class CompactJob(BaseModel):
             apply_url=row.get("apply_url"),
             id=row["job_id"],
             published_at=row.get("published_at"),
+            last_listing_update=row.get("last_listing_update"),
             department=row.get("department"),
             team=row.get("team"),
             salary=row.get("salary"),

--- a/src/jobbuddy/store.py
+++ b/src/jobbuddy/store.py
@@ -337,6 +337,7 @@ class JobStore:
                     j.location or None,
                     j.url or None,
                     _validate_date(j.published_at),
+                    _validate_date(j.last_listing_update),
                     j.department or None,
                     j.team or None,
                     j.salary or None,
@@ -350,26 +351,43 @@ class JobStore:
                 cur.executemany(
                     """INSERT INTO jobs
                        (company_slug, job_id, title, location, url, published_at,
+                        last_listing_update,
                         department, team, salary, description, ats_metadata, last_seen,
                         listing_status)
                        VALUES (%s, %s, %s, %s, %s,
                                COALESCE(%s, CURRENT_DATE),
+                               %s,
                                %s, %s, %s, %s, %s, %s, 'active')
                        ON CONFLICT(company_slug, job_id) DO UPDATE SET
                         -- Pure-insert model: a row's content (title, location,
-                        -- description, salary, dates, etc.) is fixed at first
-                        -- insert. Only operational state mutates here:
-                        --   last_seen      -- bumped every sync
-                        --   listing_status -- back to 'active' if we'd marked it removed
+                        -- description, salary, published_at, etc.) is fixed at
+                        -- first insert. Only operational state mutates here:
+                        --   last_seen           -- bumped every sync
+                        --   listing_status      -- back to 'active' on repost
+                        --   last_listing_update -- ATS-side freshness; keep
+                        --                          the most recent value
+                        --                          observed (GREATEST ignores
+                        --                          NULLs, so a fetcher that
+                        --                          doesn't surface this field
+                        --                          never clobbers an existing
+                        --                          value).
                         -- The manage_removed_at trigger clears removed_at on
                         -- the listing_status flip back to 'active'. Filling
                         -- NULLs the fetcher couldn't produce (descriptions on
                         -- stub fetchers, posted dates on TalentBrew/Avature)
                         -- is the enrich phase's job, via update_enrichment.
                         last_seen = excluded.last_seen,
-                        listing_status = 'active'
+                        listing_status = 'active',
+                        last_listing_update = GREATEST(
+                            jobs.last_listing_update,
+                            excluded.last_listing_update
+                        )
                        WHERE jobs.last_seen IS DISTINCT FROM excluded.last_seen
-                          OR jobs.listing_status <> 'active'""",
+                          OR jobs.listing_status <> 'active'
+                          OR jobs.last_listing_update IS DISTINCT FROM GREATEST(
+                                jobs.last_listing_update,
+                                excluded.last_listing_update
+                             )""",
                     upsert_params,
                     returning=False,
                 )

--- a/src/jobbuddy/store.py
+++ b/src/jobbuddy/store.py
@@ -443,7 +443,7 @@ class JobStore:
                 LEFT JOIN sync_status s ON j.company_slug = s.company_slug
                 LEFT JOIN companies c ON j.company_slug = c.slug
                 {where}
-                ORDER BY j.published_at DESC NULLS LAST
+                ORDER BY j.effective_date DESC
                 LIMIT %s
             """
         else:
@@ -456,19 +456,19 @@ class JobStore:
                     LEFT JOIN sync_status s ON j.company_slug = s.company_slug
                     LEFT JOIN companies c ON j.company_slug = c.slug
                     {where}
-                    ORDER BY j.published_at DESC NULLS LAST
+                    ORDER BY j.effective_date DESC
                     LIMIT %s
                 ),
                 ranked AS (
                     SELECT *,
                            ROW_NUMBER() OVER (
                                PARTITION BY company_slug
-                               ORDER BY published_at DESC NULLS LAST
+                               ORDER BY effective_date DESC
                            ) AS rn
                     FROM base
                 )
                 SELECT * FROM ranked
-                ORDER BY rn, published_at DESC NULLS LAST
+                ORDER BY rn, effective_date DESC
                 LIMIT %s
             """
             params.append(limit)
@@ -490,9 +490,13 @@ class JobStore:
         """Phase 1 search: FTS over fts_vector with deterministic ranking.
 
         - When `query` is set: rank by ts_rank DESC, tie-break on
-          (published_at DESC NULLS LAST, company_slug, job_id).
-        - When `query` is empty: pure published_at DESC NULLS LAST,
+          (effective_date DESC, company_slug, job_id).
+        - When `query` is empty: pure effective_date DESC,
           tie-break on (company_slug, job_id).
+        - effective_date is COALESCE(last_listing_update, published_at) —
+          ATSes that surface a freshness signal (greenhouse, amazon,
+          eightfold_v2, jibe, avature) sort by their most recent
+          ATS-side touch; others fall back to publish date.
         - Returns rows including short_jd, salary, published_at — the
           fact-dense shape the calling LLM filters on.
 
@@ -507,7 +511,7 @@ class JobStore:
 
         ts_rank_expr = "ts_rank(j.fts_vector, websearch_to_tsquery('english', %s))"
         select_extra = ""
-        order_inner = "j.published_at DESC NULLS LAST, j.company_slug, j.job_id"
+        order_inner = "j.effective_date DESC, j.company_slug, j.job_id"
         if query:
             select_extra = f", {ts_rank_expr} AS rank"
             params.insert(0, query)  # bound to the SELECT-list ts_rank
@@ -638,7 +642,7 @@ class JobStore:
         )
 
         select_extra = ""
-        order_by = "j.published_at DESC NULLS LAST, j.company_slug, j.job_id"
+        order_by = "j.effective_date DESC, j.company_slug, j.job_id"
         if query:
             ts_rank_expr = "ts_rank(j.fts_vector, websearch_to_tsquery('english', %s))"
             headline_expr = (
@@ -668,11 +672,13 @@ class JobStore:
         top_rows = []
         for row in rows:
             r = dict(row)
+            llu = r.get("last_listing_update")
             top_row: dict = {
                 "job_id": r["job_id"],
                 "title": r["title"],
                 "location": r.get("location") or "",
                 "posted": r["published_at"].isoformat() if r.get("published_at") else None,
+                "updated": llu.isoformat() if llu else None,
                 "url": r.get("url") or "",
                 "salary": r.get("salary"),
                 "company_slug": r["company_slug"],
@@ -952,7 +958,11 @@ class JobStore:
             params.append(exclude_companies)
 
         if posted_after:
-            conditions.append("j.published_at >= %s")
+            # Match against effective_date (COALESCE(last_listing_update,
+            # published_at)) so "posted in the last 30 days" surfaces
+            # listings the ATS still considers fresh — not just listings
+            # whose publish date happens to be recent. See migration 019.
+            conditions.append("j.effective_date >= %s")
             params.append(posted_after)
 
         if title:

--- a/src/jobbuddy/store.py
+++ b/src/jobbuddy/store.py
@@ -366,11 +366,17 @@ class JobStore:
                         --   listing_status      -- back to 'active' on repost
                         --   last_listing_update -- ATS-side freshness; keep
                         --                          the most recent value
-                        --                          observed (GREATEST ignores
-                        --                          NULLs, so a fetcher that
-                        --                          doesn't surface this field
-                        --                          never clobbers an existing
-                        --                          value).
+                        --                          observed. PostgreSQL's
+                        --                          GREATEST is non-standard
+                        --                          and ignores NULLs (ANSI
+                        --                          SQL would poison the
+                        --                          result), so a fetcher
+                        --                          that doesn't surface this
+                        --                          field never clobbers an
+                        --                          existing value. Do NOT
+                        --                          "fix" this with an outer
+                        --                          COALESCE — it would break
+                        --                          the NULL-preserve case.
                         -- The manage_removed_at trigger clears removed_at on
                         -- the listing_status flip back to 'active'. Filling
                         -- NULLs the fetcher couldn't produce (descriptions on

--- a/tests/test_amazon_fetcher.py
+++ b/tests/test_amazon_fetcher.py
@@ -116,6 +116,30 @@ def test_parse_hit():
     assert job.published_at is not None
 
 
+def test_parse_hit_extracts_last_listing_update():
+    """`updatedDate` epoch field becomes last_listing_update."""
+    hit = {"fields": {
+        "icimsJobId": ["10406569"],
+        "title": ["SDE"],
+        "createdDate": ["1700000000"],   # 2023-11-14
+        "updatedDate": ["1776450511"],   # 2026-04-17
+    }}
+    job = AmazonFetcher("")._parse_hit(hit)
+    assert job.published_at is not None
+    assert job.last_listing_update is not None
+    assert job.last_listing_update > job.published_at
+
+
+def test_parse_hit_no_updated_date_leaves_null():
+    hit = {"fields": {
+        "icimsJobId": ["1"],
+        "title": ["SDE"],
+        "createdDate": ["1776450511"],
+    }}
+    job = AmazonFetcher("")._parse_hit(hit)
+    assert job.last_listing_update is None
+
+
 def test_parse_hit_missing_fields():
     f = AmazonFetcher("")
     hit = {"fields": {"icimsJobId": ["99999"], "title": ["Test Role"]}}

--- a/tests/test_eightfold_v2.py
+++ b/tests/test_eightfold_v2.py
@@ -1,0 +1,45 @@
+"""Tests for the Eightfold v2 fetcher's date extraction.
+
+`t_create` and `t_update` are both epoch-second fields on every position.
+We map them to `published_at` and `last_listing_update` respectively.
+"""
+
+from datetime import date
+
+from jobbuddy.fetchers.eightfold_v2 import EightfoldV2Fetcher
+
+
+def _make_fetcher() -> EightfoldV2Fetcher:
+    return EightfoldV2Fetcher(
+        board="acme",
+        base_url="https://acme.eightfold.ai",
+        domain="acme.com",
+    )
+
+
+def test_position_to_job_extracts_both_dates():
+    f = _make_fetcher()
+    pos = {
+        "id": 12345,
+        "name": "SWE",
+        "t_create": 1700000000,  # 2023-11-14
+        "t_update": 1776000000,  # 2026-04-12
+    }
+    job = f._position_to_job(pos)
+    assert job.published_at == date(2023, 11, 14)
+    assert job.last_listing_update == date(2026, 4, 12)
+
+
+def test_position_with_no_t_update_leaves_null():
+    f = _make_fetcher()
+    pos = {"id": 1, "name": "SWE", "t_create": 1776000000}
+    job = f._position_to_job(pos)
+    assert job.last_listing_update is None
+    assert job.published_at == date(2026, 4, 12)
+
+
+def test_position_with_no_dates_at_all_is_null():
+    f = _make_fetcher()
+    job = f._position_to_job({"id": 1, "name": "SWE"})
+    assert job.published_at is None
+    assert job.last_listing_update is None

--- a/tests/test_greenhouse.py
+++ b/tests/test_greenhouse.py
@@ -1,0 +1,77 @@
+"""Tests for the Greenhouse fetcher.
+
+Greenhouse exposes both `first_published` and `updated_at` on every job in
+the board API. We use `first_published` for `published_at` (publish-date
+semantics) and `updated_at` for `last_listing_update` (freshness signal).
+See issue #53 for the live-probe analysis that motivated splitting these
+into two columns.
+"""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+import httpx
+
+from jobbuddy.fetchers.greenhouse import GreenhouseFetcher
+
+
+SAMPLE_BOARD = {
+    "jobs": [
+        {
+            "id": 159214,
+            "title": "Sales Engineer",
+            "absolute_url": "https://boards.greenhouse.io/acme/jobs/159214",
+            "location": {"name": "Remote"},
+            "departments": [{"name": "Sales"}],
+            "first_published": "2019-01-07T22:26:28-05:00",
+            "updated_at": "2026-05-06T16:25:59-04:00",
+            "content": "<p>desc</p>",
+        },
+        {
+            "id": 200000,
+            "title": "Greenfield Role",
+            "absolute_url": "https://boards.greenhouse.io/acme/jobs/200000",
+            "location": {"name": "NYC"},
+            "departments": [],
+            # Older payload shape: no updated_at field at all.
+            "first_published": "2026-04-01T00:00:00Z",
+            "content": "",
+        },
+    ]
+}
+
+
+def _make_fetcher() -> GreenhouseFetcher:
+    f = GreenhouseFetcher("acme")
+    f.client = MagicMock()
+    return f
+
+
+def _mock_response(json_data) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def test_published_at_uses_first_published():
+    """Pure-insert date column stays on first_published — backward-compatible."""
+    f = _make_fetcher()
+    f.client.get.return_value = _mock_response(SAMPLE_BOARD)
+    jobs = f.list_jobs()
+    assert jobs[0].published_at == date(2019, 1, 7)
+
+
+def test_last_listing_update_uses_updated_at():
+    f = _make_fetcher()
+    f.client.get.return_value = _mock_response(SAMPLE_BOARD)
+    jobs = f.list_jobs()
+    assert jobs[0].last_listing_update == date(2026, 5, 6)
+
+
+def test_missing_updated_at_leaves_last_listing_update_null():
+    f = _make_fetcher()
+    f.client.get.return_value = _mock_response(SAMPLE_BOARD)
+    jobs = f.list_jobs()
+    assert jobs[1].last_listing_update is None
+    assert jobs[1].published_at == date(2026, 4, 1)

--- a/tests/test_jibe.py
+++ b/tests/test_jibe.py
@@ -140,6 +140,9 @@ class TestJibeListJobs:
         assert jobs[0].location == "Wichita, Kansas, United States"
         assert jobs[0].department == "Engineering"
         assert jobs[0].published_at == date(2026, 4, 22)
+        # Sample data has no update_date or meta_data.icims.date_updated for
+        # this row, so last_listing_update is NULL.
+        assert jobs[0].last_listing_update is None
         assert "full" in jobs[0].description
         assert "<p>" not in jobs[0].description
         assert jobs[0].apply_url == "https://careers-spiritaero.icims.com/jobs/16625/login"
@@ -281,6 +284,37 @@ class TestJibeFetchJob:
 # ---------------------------------------------------------------------------
 # Configuration validation
 # ---------------------------------------------------------------------------
+
+
+class TestJibeLastListingUpdate:
+    def test_extracts_update_date(self):
+        f = make_jibe_fetcher()
+        job = f._parse_job({
+            "slug": "1", "title": "Eng",
+            "posted_date": "2026-01-01T00:00:00+0000",
+            "update_date": "2026-05-01T00:00:00+0000",
+        })
+        assert job.published_at == date(2026, 1, 1)
+        assert job.last_listing_update == date(2026, 5, 1)
+
+    def test_falls_back_to_icims_date_updated(self):
+        """Older payloads omit update_date but expose
+        meta_data.icims.date_updated."""
+        f = make_jibe_fetcher()
+        job = f._parse_job({
+            "slug": "1", "title": "Eng",
+            "posted_date": "2026-01-01T00:00:00+0000",
+            "meta_data": {"icims": {"date_updated": "2026-04-15T12:00:00+0000"}},
+        })
+        assert job.last_listing_update == date(2026, 4, 15)
+
+    def test_no_update_field_leaves_null(self):
+        f = make_jibe_fetcher()
+        job = f._parse_job({
+            "slug": "1", "title": "Eng",
+            "posted_date": "2026-01-01T00:00:00+0000",
+        })
+        assert job.last_listing_update is None
 
 
 class TestJibeConfig:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -92,6 +92,22 @@ class TestSearchJobsFts:
         rows = store.search_jobs_fts(posted_after=cutoff, limit=20)
         assert [r["job_id"] for r in rows] == ["new"]
 
+    def test_posted_after_uses_freshness_when_present(self, store):
+        """A job whose `published_at` is years stale but whose
+        `last_listing_update` is recent IS in-window for posted_after."""
+        today = date.today()
+        old_pub = (today - timedelta(days=400)).isoformat()
+        recent = (today - timedelta(days=2)).isoformat()
+        _seed_distilled(store, "acme", "stale", title="Stale", short_jd="x",
+                        published_at=old_pub)
+        store.upsert_jobs("acme", [
+            make_job(id="refreshed", title="Refreshed",
+                     published_at=old_pub, last_listing_update=recent),
+        ])
+        cutoff = (today - timedelta(days=7)).isoformat()
+        rows = store.search_jobs_fts(posted_after=cutoff, limit=20)
+        assert [r["job_id"] for r in rows] == ["refreshed"]
+
     def test_excludes_removed_listings(self, store):
         _seed_distilled(store, "acme", "1", title="A", short_jd="x")
         _seed_distilled(store, "acme", "2", title="B", short_jd="x")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -363,6 +363,55 @@ class TestQueryFilters:
         assert len(rows) == 2
 
 
+class TestEffectiveDate:
+    """Generated `effective_date = COALESCE(last_listing_update, published_at)`
+    drives `posted_after` filtering and ordering. ATSes that surface a
+    freshness signal sort by their most recent ATS-side touch; others fall
+    back to publish date — same behavior as before for those rows."""
+
+    def test_effective_date_falls_back_to_published_at(self, store):
+        store.upsert_jobs("acme", [
+            make_job("1", published_at="2026-01-01"),  # no last_listing_update
+        ])
+        row = store.conn.execute(
+            "SELECT effective_date FROM jobs WHERE company_slug='acme'"
+        ).fetchone()
+        assert row["effective_date"].isoformat() == "2026-01-01"
+
+    def test_effective_date_uses_last_listing_update_when_present(self, store):
+        store.upsert_jobs("acme", [
+            make_job("1", published_at="2019-01-01",
+                     last_listing_update="2026-05-01"),
+        ])
+        row = store.conn.execute(
+            "SELECT effective_date FROM jobs WHERE company_slug='acme'"
+        ).fetchone()
+        assert row["effective_date"].isoformat() == "2026-05-01"
+
+    def test_posted_after_uses_effective_date(self, store):
+        """A 2019 publish date with a 2026 freshness touch is in-window for
+        a 2026 `posted_after` filter — the whole reason effective_date exists."""
+        store.upsert_jobs("acme", [
+            make_job("stale", published_at="2019-01-01"),
+            make_job("refreshed", published_at="2019-01-01",
+                     last_listing_update="2026-05-01"),
+        ])
+        rows = store.query_jobs(posted_after="2026-01-01")
+        ids = {r["job_id"] for r in rows}
+        assert ids == {"refreshed"}
+
+    def test_query_orders_by_effective_date(self, store):
+        store.upsert_jobs("acme", [
+            make_job("a", published_at="2026-04-01"),
+            make_job("b", published_at="2019-01-01",
+                     last_listing_update="2026-05-01"),
+            make_job("c", published_at="2026-03-01"),
+        ])
+        rows = store.query_jobs(companies=["acme"])
+        # b's effective_date is 2026-05-01 (newest), so it comes first
+        assert [r["job_id"] for r in rows] == ["b", "a", "c"]
+
+
 class TestFullTextSearch:
     """Tests for PostgreSQL FTS replacing ILIKE title filter."""
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -82,6 +82,53 @@ class TestUpsertAndQuery:
         assert rows[0]["title"] == "PM"
         assert rows[0]["location"] == "Seattle"
 
+    def test_last_listing_update_writes_on_insert(self, store):
+        """Fetcher-supplied last_listing_update lands on first insert."""
+        store.upsert_jobs("acme", [
+            make_job("1", last_listing_update="2026-05-01"),
+        ])
+        row = store.conn.execute(
+            "SELECT last_listing_update FROM jobs WHERE company_slug='acme' AND job_id='1'"
+        ).fetchone()
+        assert row["last_listing_update"].isoformat() == "2026-05-01"
+
+    def test_last_listing_update_advances_on_resync(self, store):
+        """Newer ATS-side update overrides the stored value (GREATEST)."""
+        store.upsert_jobs("acme", [
+            make_job("1", last_listing_update="2026-05-01"),
+        ])
+        store.upsert_jobs("acme", [
+            make_job("1", last_listing_update="2026-05-09"),
+        ])
+        row = store.conn.execute(
+            "SELECT last_listing_update FROM jobs WHERE company_slug='acme' AND job_id='1'"
+        ).fetchone()
+        assert row["last_listing_update"].isoformat() == "2026-05-09"
+
+    def test_last_listing_update_keeps_newer_when_older_arrives(self, store):
+        """Out-of-order syncs never regress the column (GREATEST keeps max)."""
+        store.upsert_jobs("acme", [
+            make_job("1", last_listing_update="2026-05-09"),
+        ])
+        store.upsert_jobs("acme", [
+            make_job("1", last_listing_update="2026-04-01"),
+        ])
+        row = store.conn.execute(
+            "SELECT last_listing_update FROM jobs WHERE company_slug='acme' AND job_id='1'"
+        ).fetchone()
+        assert row["last_listing_update"].isoformat() == "2026-05-09"
+
+    def test_last_listing_update_null_does_not_clobber(self, store):
+        """A fetcher that doesn't surface this field (NULL) preserves the value."""
+        store.upsert_jobs("acme", [
+            make_job("1", last_listing_update="2026-05-01"),
+        ])
+        store.upsert_jobs("acme", [make_job("1")])  # no last_listing_update
+        row = store.conn.execute(
+            "SELECT last_listing_update FROM jobs WHERE company_slug='acme' AND job_id='1'"
+        ).fetchone()
+        assert row["last_listing_update"].isoformat() == "2026-05-01"
+
     def test_upsert_marks_removed_jobs(self, store):
         store.upsert_jobs("acme", [make_job("1"), make_job("2")])
         assert len(store.query_jobs()) == 2


### PR DESCRIPTION
## Summary

Adds a `jobs.last_listing_update DATE NULL` column populated from each ATS's per-platform "updated" field where one exists publicly, plus a generated `jobs.effective_date = COALESCE(last_listing_update, published_at)` column that drives freshness-aware filtering and ranking. Resolves the data-quality issue where ~64% of "year+ old" Greenhouse postings in the DB were mislabeled (their `first_published` is years stale, but `updated_at` was within 30 days for ~99% of that cohort).

`published_at` keeps its pure-insert semantics. `last_listing_update` updates on every sync via `GREATEST()` so a newer ATS-side timestamp wins and a NULL never clobbers an existing value. `effective_date` is the one source of truth for "last sign of life" — used for ordering and `posted_after` filtering across search, query, and per-company surveys.

Closes #53. Closes #58.

## Per-fetcher mapping

| Fetcher       | Source field for `last_listing_update`                    |
|---------------|-----------------------------------------------------------|
| greenhouse    | `updated_at` (board API)                                  |
| amazon        | `updatedDate` (search hit fields)                         |
| eightfold_v2  | `t_update` (epoch seconds)                                |
| jibe          | `update_date`, falling back to `meta_data.icims.date_updated` |
| avature       | sitemap `<lastmod>` (also feeds `published_at` — Avature has no separate first-publish field) |
| (others)      | NULL — public API exposes only one date                   |

The mapping comes from live JSON probes against every wired ATS (see issue #53 for the full investigation).

## What the LLM sees now

- `CompactJob` (detail payload from `get_job_post_details`) gains `last_listing_update`.
- `JobRow` (search/survey row) gains an `updated` field alongside `posted` so the LLM can see at a glance when a "2019 posted" listing has actually been touched in the ATS this week.
- `posted_after` filters and recency ordering switch to `effective_date` — "posted in the last 30 days" surfaces ATS-fresh listings, not just recently-first-published ones. Listings whose fetcher doesn't surface last_listing_update behave identically to before (`effective_date = published_at`).

## Files

- New migration [018_jobs_last_listing_update.sql](src/jobbuddy/migrations/018_jobs_last_listing_update.sql) — adds the raw column.
- New migration [019_jobs_effective_date.sql](src/jobbuddy/migrations/019_jobs_effective_date.sql) — generated `effective_date` + supporting index.
- [Job model](src/jobbuddy/models.py) and [CompactJob](src/jobbuddy/models.py) gain `last_listing_update`; [JobRow](src/jobbuddy/core.py) gains `updated`.
- [JobStore.upsert_jobs](src/jobbuddy/store.py) writes on insert and `GREATEST`s on conflict (with a comment warning against COALESCE-wrapping the GREATEST and breaking the NULL-preserve case).
- [search_jobs_fts / query_jobs / survey_jobs_by_company](src/jobbuddy/store.py) reorder + filter on `effective_date`.
- Five fetcher updates ([greenhouse](src/jobbuddy/fetchers/greenhouse.py), [amazon](src/jobbuddy/fetchers/amazon.py), [eightfold_v2](src/jobbuddy/fetchers/eightfold_v2.py), [jibe](src/jobbuddy/fetchers/jibe.py), [avature](src/jobbuddy/fetchers/avature.py)).
- [docs/architecture.md](docs/architecture.md) gains a "Date columns" section.

## Test plan

- [x] `uv run pytest tests/` — 490 passed.
- [ ] After merge: `jsb migrate` against prod adds both columns. Existing rows have `last_listing_update = NULL` (so `effective_date = published_at`); values fill in on subsequent syncs as fetchers re-observe each listing — ordering for those rows shifts toward freshness as the data lands.
- [ ] Spot-check a Greenhouse company's rows after one sync cycle: stale-looking rows should now carry a recent `last_listing_update` (and matching `effective_date`) while `published_at` stays unchanged. A `posted_after=last 30 days` query should start returning rows whose `published_at` is older than the cutoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)