### PR TITLE
watchlists: account-scoped saved searches with freshness histogram

### DIFF
--- a/src/jobbuddy/core.py
+++ b/src/jobbuddy/core.py
@@ -255,9 +255,45 @@ def find_companies(
     }
 
 
+_WATCHLIST_FILTER_KEYS = {"query", "location_filter", "posted_since", "exclude_companies"}
+
+
+def merge_watchlist_defaults(
+    watchlist: dict,
+    *,
+    query: str,
+    exclude_companies: list[str] | None,
+    location: str,
+    posted_since: str,
+    companies: list[str] | None = None,
+) -> tuple[str, list[str] | None, str, str, list[str] | None]:
+    """Layer a watchlist's saved defaults under caller-passed arguments.
+
+    Explicit caller args win; the watchlist fills in what the caller left
+    empty/None. Returns the resolved (query, exclude_companies, location,
+    posted_since, companies) tuple. The `filter` JSONB shape is the same
+    keyword set as `search_jobs` minus `limit`.
+    """
+    f = watchlist.get("filter") or {}
+    unknown = set(f) - _WATCHLIST_FILTER_KEYS
+    if unknown:
+        raise ValueError(
+            f"watchlist filter has unknown keys: {sorted(unknown)}; "
+            f"allowed: {sorted(_WATCHLIST_FILTER_KEYS)}"
+        )
+
+    resolved_query = query or (f.get("query") or "")
+    resolved_location = location or (f.get("location_filter") or "")
+    resolved_posted_since = posted_since or (f.get("posted_since") or "")
+    resolved_exclude = exclude_companies if exclude_companies else (f.get("exclude_companies") or None)
+    resolved_companies = companies if companies else (watchlist.get("companies") or None)
+    return resolved_query, resolved_exclude, resolved_location, resolved_posted_since, resolved_companies
+
+
 def search_jobs(
     *,
     query: str = "",
+    companies: list[str] | None = None,
     exclude_companies: list[str] | None = None,
     location: str = "",
     posted_since: str = "",
@@ -266,13 +302,15 @@ def search_jobs(
     """Flat ranked job search across the whole stored corpus.
 
     Returns rows ranked by Postgres FTS when `query` is set, or by
-    `published_at DESC` when it is not. Use `survey_jobs_by_companies` for
-    a per-company envelope keyed by slug.
+    `effective_date DESC` when it is not. Optionally scope to a specific
+    `companies` list — useful when called via a watchlist. Use
+    `survey_jobs_by_companies` for a per-company envelope keyed by slug.
 
-    Raises ValueError on an unknown excluded company or a bad duration.
+    Raises ValueError on an unknown company or a bad duration.
     """
     from jobbuddy.store import JobStore
 
+    company_slugs = resolve_company_slugs(companies) if companies else None
     exclude_slugs = resolve_company_slugs(exclude_companies) if exclude_companies else None
     posted_after = parse_duration_to_date(posted_since) if posted_since else None
 
@@ -280,7 +318,7 @@ def search_jobs(
     try:
         rows = store.search_jobs_fts(
             query=query or None,
-            companies=None,
+            companies=company_slugs,
             exclude_companies=exclude_slugs,
             location=location or None,
             posted_after=posted_after,

--- a/src/jobbuddy/mcp_server.py
+++ b/src/jobbuddy/mcp_server.py
@@ -417,6 +417,12 @@ _QUERY_FIELD_DESC = (
 })
 def search_jobs(
     query: Annotated[str, Field(default="", description=_QUERY_FIELD_DESC)] = "",
+    watchlist: Annotated[str, Field(default="", description=(
+        "Watchlist slug to scope this search against. Loads the watchlist's "
+        "saved companies and filter defaults (query, location_filter, "
+        "posted_since, exclude_companies) as a base; any explicitly-passed "
+        "param overrides. List available watchlists with `watchlist_list`."
+    ))] = "",
     exclude_companies: Annotated[list[str], Field(default=[], description="Companies the user has ruled out (e.g. ['microsoft', 'meta']).")] = [],
     location_filter: Annotated[str, Field(default="", description="Where the user wants to work. Substring match on the posting's location field. Comma-separated for OR (e.g. 'seattle,remote').")] = "",
     posted_since: Annotated[str, Field(default="", description="How recent the user wants. Examples: '24h', '3d', '1w', '2w'. Use this instead of fetching everything and filtering client-side.")] = "",
@@ -431,16 +437,40 @@ def search_jobs(
     For a watch-list-scoped scan or per-company breakdown, use
     `survey_jobs_by_companies` instead.
 
+    Pass `watchlist=<slug>` to scope to a saved watchlist — its companies
+    and filter become defaults, any explicit param overrides. Call
+    `watchlist_list` first to see what's saved.
+
     Rows are fact-dense (snippet + salary + posted + location inline), so
     do NOT call `get_job_post_details` per row to rank or filter — only
     when the user asks for the full description. Rows the user has already
     logged activity against carry an `applied` summary so you don't surface
     them as fresh leads. Returns an empty list when nothing matches; if
     the registry seems empty, suggest the human run `jsb sync` to refresh."""
-    from jobbuddy.core import search_jobs as core_search_jobs
+    from jobbuddy.core import merge_watchlist_defaults, search_jobs as core_search_jobs
+    from jobbuddy.store import JobStore
+
+    companies: list[str] | None = None
+    if watchlist:
+        with JobStore() as store:
+            wl = store.get_watchlist(account.id, watchlist)
+        if not wl:
+            return []  # unknown slug for this account — empty result, not an error
+        try:
+            query, exclude_companies_resolved, location_filter, posted_since, companies = merge_watchlist_defaults(
+                wl,
+                query=query,
+                exclude_companies=exclude_companies or None,
+                location=location_filter,
+                posted_since=posted_since,
+            )
+        except ValueError:
+            return []  # corrupted filter shape; bail rather than crash the tool
+        exclude_companies = exclude_companies_resolved or []
 
     rows = core_search_jobs(
         query=query,
+        companies=companies,
         exclude_companies=exclude_companies or None,
         location=location_filter,
         posted_since=posted_since,
@@ -448,6 +478,153 @@ def search_jobs(
     )
     _decorate_applied(rows, account.id)
     return rows
+
+
+# ---------------------------------------------------------------------------
+# Watchlist CRUD
+# ---------------------------------------------------------------------------
+
+
+_WATCHLIST_FILTER_DESC = (
+    "Saved-search defaults applied when search_jobs is called with "
+    "watchlist=<slug>. JSON object with optional keys matching search_jobs "
+    "params: `query`, `location_filter`, `posted_since`, "
+    "`exclude_companies`. Keys not set fall through to caller args. "
+    "Example: {\"query\": \"staff engineer\", \"posted_since\": \"7d\"}."
+)
+
+
+@mcp.tool(annotations={
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": False,
+    "openWorldHint": False,
+})
+def watchlist_create(
+    name: Annotated[str, Field(description="Human-readable watchlist name, e.g. 'AI-as-product companies'.")],
+    slug: Annotated[str, Field(default="", description="URL-style identifier. Auto-derived from `name` (lowercased, hyphenated) if omitted. Must be unique per account.")] = "",
+    filter: Annotated[dict, Field(default={}, description=_WATCHLIST_FILTER_DESC)] = {},
+    company_slugs: Annotated[list[str], Field(default=[], description="Initial company roster — list of registered slugs (from find_companies or the ats://companies resource).")] = [],
+    notes: Annotated[str, Field(default="", description="Free-text notes about why this watchlist exists.")] = "",
+    account: Account = CurrentAccount(),
+) -> str:
+    """Create a watchlist — a saved search definition (companies + filter defaults).
+
+    Watchlists are durable, account-scoped saved searches. Once created,
+    pass `watchlist=<slug>` to `search_jobs` to get jobs matching its
+    companies + filters. Use this after the user expresses a recurring
+    interest ("save these AI companies as my watch list", "I want to
+    track climate-tech jobs"). Returns the new watchlist row.
+    """
+    from jobbuddy.models import slugify
+    from jobbuddy.store import JobStore
+
+    final_slug = slug.strip() or slugify(name)
+    if not final_slug:
+        return "Error: could not derive a slug from name; pass `slug` explicitly."
+
+    try:
+        with JobStore() as store:
+            row = store.create_watchlist(
+                account.id,
+                slug=final_slug,
+                name=name,
+                filter=filter or {},
+                notes=notes or None,
+                company_slugs=company_slugs or None,
+            )
+    except ValueError as e:
+        return f"Error: {e}"
+    return json.dumps(row, indent=2, default=str)
+
+
+@mcp.tool(annotations={
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": False,
+})
+def watchlist_update(
+    slug: Annotated[str, Field(description="Slug of the watchlist to update.")],
+    name: Annotated[str, Field(default="", description="New display name (leave empty to keep current).")] = "",
+    notes: Annotated[str, Field(default="", description="New notes (leave empty to keep current).")] = "",
+    filter: Annotated[dict | None, Field(default=None, description=_WATCHLIST_FILTER_DESC + " Pass null to leave unchanged; pass {} to clear.")] = None,
+    add: Annotated[list[str], Field(default=[], description="Company slugs to add to the watchlist.")] = [],
+    remove: Annotated[list[str], Field(default=[], description="Company slugs to remove from the watchlist.")] = [],
+    account: Account = CurrentAccount(),
+) -> str:
+    """Update a watchlist's metadata, filter, or company roster.
+
+    Pass only the fields you want to change. `add` / `remove` mutate the
+    member roster idempotently — adding a company that's already a member
+    is a no-op, as is removing one that isn't.
+    """
+    from jobbuddy.store import JobStore
+
+    with JobStore() as store:
+        row = store.update_watchlist(
+            account.id,
+            slug,
+            name=name or None,
+            notes=notes or None,
+            filter=filter,
+            add=add or None,
+            remove=remove or None,
+        )
+    if row is None:
+        return f"Error: watchlist '{slug}' not found for this account."
+    return json.dumps(row, indent=2, default=str)
+
+
+@mcp.tool(annotations={
+    "readOnlyHint": False,
+    "destructiveHint": True,
+    "idempotentHint": True,
+    "openWorldHint": False,
+})
+def watchlist_delete(
+    slug: Annotated[str, Field(description="Slug of the watchlist to delete.")],
+    account: Account = CurrentAccount(),
+) -> str:
+    """Delete a watchlist. The companies and any jobs are untouched; only
+    the saved search definition goes away."""
+    from jobbuddy.store import JobStore
+
+    with JobStore() as store:
+        removed = store.delete_watchlist(account.id, slug)
+    if not removed:
+        return f"Error: watchlist '{slug}' not found for this account."
+    return _compact({"status": "ok", "deleted": slug})
+
+
+@mcp.tool(annotations={
+    "readOnlyHint": True,
+    "idempotentHint": True,
+    "openWorldHint": False,
+})
+def watchlist_list(
+    account: Account = CurrentAccount(),
+) -> str:
+    """List this account's watchlists with precomputed activity summaries.
+
+    Returns inventory only — no job listings. Each row carries `slug`,
+    `name`, `notes`, `filter`, `companies`, and a `counts` block with
+    `total_active`, `posted_1d`, `posted_7d`, `posted_30d`, and `applied`
+    (rows the user has already logged Application activity against any
+    company in the watchlist).
+
+    Use as a navigation aid: pick a watchlist by which one has fresh
+    activity (`posted_1d` / `posted_7d`), then call
+    `search_jobs(watchlist=<slug>, posted_since=...)` for the actual
+    listings.
+
+    Takes no parameters — time windows belong on `search_jobs`, not on
+    this metadata endpoint."""
+    from jobbuddy.store import JobStore
+
+    with JobStore() as store:
+        rows = store.list_watchlists(account.id)
+    return json.dumps(rows, indent=2, default=str)
 
 
 @mcp.tool(annotations={
@@ -729,6 +906,8 @@ async def assert_account_dependency_stripped() -> None:
     for tool_name in (
         "log_job_application", "log_job_activity", "search_jobs",
         "find_companies", "review_activity_log",
+        "watchlist_create", "watchlist_update", "watchlist_delete",
+        "watchlist_list",
     ):
         tool = await mcp.get_tool(tool_name)
         schema = tool.parameters

--- a/src/jobbuddy/migrations/020_watchlists.sql
+++ b/src/jobbuddy/migrations/020_watchlists.sql
@@ -1,0 +1,38 @@
+-- Watchlists: account-scoped saved searches (company roster + default filters).
+--
+-- A watchlist is a saved-search definition, not a job list. Job listings
+-- live in `jobs` and are surfaced via search_jobs(watchlist=slug). The
+-- watchlist's `filter` (query, location, posted_since, etc.) and member
+-- companies become defaults that the caller can override per-call.
+--
+-- Account-scoped slugs: `ai_focus` means different things for different
+-- humans. The UNIQUE (account_id, slug) constraint enforces uniqueness
+-- per owner, not globally.
+--
+-- `companies.slug` is itself the surrogate key for companies (TEXT
+-- PRIMARY KEY, no separate id column), so member FK targets slug
+-- directly. Dead slugs in a watchlist are junk, not history — CASCADE
+-- both ways.
+
+CREATE TABLE watchlists (
+    id          UUID PRIMARY KEY DEFAULT uuidv7(),
+    account_id  UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    slug        TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    notes       TEXT,
+    filter      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (account_id, slug)
+);
+
+CREATE INDEX idx_watchlists_account ON watchlists (account_id);
+
+CREATE TABLE watchlist_members (
+    watchlist_id  UUID NOT NULL REFERENCES watchlists(id) ON DELETE CASCADE,
+    company_slug  TEXT NOT NULL REFERENCES companies(slug) ON DELETE CASCADE,
+    added_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (watchlist_id, company_slug)
+);
+
+CREATE INDEX idx_watchlist_members_company ON watchlist_members (company_slug);

--- a/src/jobbuddy/store.py
+++ b/src/jobbuddy/store.py
@@ -1245,6 +1245,239 @@ class JobStore:
         return self._hydrate_account(row) if row else None
 
     # -------------------------------------------------------------------
+    # Watchlists
+    # -------------------------------------------------------------------
+
+    def _watchlist_row(self, row: dict, companies: list[str]) -> dict:
+        """Shape a watchlists row + member slugs into the consumer dict."""
+        return {
+            "id": row["id"],
+            "slug": row["slug"],
+            "name": row["name"],
+            "notes": row["notes"],
+            "filter": row["filter"] or {},
+            "companies": companies,
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    def create_watchlist(
+        self,
+        account_id: UUID,
+        *,
+        slug: str,
+        name: str,
+        filter: dict | None = None,
+        notes: str | None = None,
+        company_slugs: list[str] | None = None,
+    ) -> dict:
+        """Create a watchlist for one account. Returns the new row.
+
+        Raises ValueError on (account_id, slug) conflict so the MCP/CLI
+        layer can map it to a user-facing error.
+        """
+        try:
+            row = self.conn.execute(
+                """INSERT INTO watchlists (account_id, slug, name, notes, filter)
+                   VALUES (%s, %s, %s, %s, %s)
+                   RETURNING *""",
+                (account_id, slug, name, notes, Json(filter or {})),
+            ).fetchone()
+        except psycopg.errors.UniqueViolation as e:
+            raise ValueError(
+                f"Watchlist slug '{slug}' already exists for this account"
+            ) from e
+        assert row is not None
+        members = self._add_members(row["id"], company_slugs or [])
+        return self._watchlist_row(row, members)
+
+    def _add_members(self, watchlist_id: UUID, company_slugs: list[str]) -> list[str]:
+        """Insert members (ignoring conflicts and unknown slugs). Returns the
+        current full member list for the watchlist."""
+        if company_slugs:
+            with self.conn.cursor() as cur:
+                cur.executemany(
+                    """INSERT INTO watchlist_members (watchlist_id, company_slug)
+                       SELECT %s, %s
+                       WHERE EXISTS (SELECT 1 FROM companies WHERE slug = %s)
+                       ON CONFLICT DO NOTHING""",
+                    [(watchlist_id, s, s) for s in company_slugs],
+                    returning=False,
+                )
+        return self._list_members(watchlist_id)
+
+    def _list_members(self, watchlist_id: UUID) -> list[str]:
+        rows = self.conn.execute(
+            """SELECT company_slug FROM watchlist_members
+               WHERE watchlist_id = %s ORDER BY company_slug""",
+            (watchlist_id,),
+        ).fetchall()
+        return [r["company_slug"] for r in rows]
+
+    def get_watchlist(self, account_id: UUID, slug: str) -> dict | None:
+        """Fetch one watchlist scoped to an account. Returns None if absent."""
+        row = self.conn.execute(
+            """SELECT * FROM watchlists
+               WHERE account_id = %s AND slug = %s""",
+            (account_id, slug),
+        ).fetchone()
+        if not row:
+            return None
+        return self._watchlist_row(row, self._list_members(row["id"]))
+
+    def update_watchlist(
+        self,
+        account_id: UUID,
+        slug: str,
+        *,
+        name: str | None = None,
+        notes: str | None = None,
+        filter: dict | None = None,
+        add: list[str] | None = None,
+        remove: list[str] | None = None,
+    ) -> dict | None:
+        """Update a watchlist (mutates only fields passed; None means leave alone).
+
+        `add` / `remove` mutate the member roster. Returns the refreshed
+        row, or None if no such watchlist exists for this account.
+        """
+        existing = self.conn.execute(
+            "SELECT id FROM watchlists WHERE account_id = %s AND slug = %s",
+            (account_id, slug),
+        ).fetchone()
+        if not existing:
+            return None
+        wid = existing["id"]
+
+        sets: list[LiteralString] = []
+        params: list = []
+        if name is not None:
+            sets.append("name = %s")
+            params.append(name)
+        if notes is not None:
+            sets.append("notes = %s")
+            params.append(notes)
+        if filter is not None:
+            sets.append("filter = %s")
+            params.append(Json(filter))
+        if sets:
+            sets.append("updated_at = now()")
+            params.extend([account_id, slug])
+            self.conn.execute(
+                f"UPDATE watchlists SET {', '.join(sets)} "
+                f"WHERE account_id = %s AND slug = %s",
+                params,
+            )
+
+        if remove:
+            self.conn.execute(
+                """DELETE FROM watchlist_members
+                   WHERE watchlist_id = %s AND company_slug = ANY(%s)""",
+                (wid, remove),
+            )
+        if add:
+            self._add_members(wid, add)
+
+        return self.get_watchlist(account_id, slug)
+
+    def delete_watchlist(self, account_id: UUID, slug: str) -> bool:
+        """Delete a watchlist. Returns True if a row was removed."""
+        result = self.conn.execute(
+            "DELETE FROM watchlists WHERE account_id = %s AND slug = %s",
+            (account_id, slug),
+        )
+        return result.rowcount > 0
+
+    def list_watchlists(self, account_id: UUID) -> list[dict]:
+        """Return all watchlists for one account, with precomputed summary counts.
+
+        Counts are computed in one pass over `jobs`:
+          - posted_1d / posted_7d / posted_30d: active jobs in the watchlist's
+            companies whose `effective_date` (COALESCE of last_listing_update
+            and published_at) falls within the window.
+          - total_active: all active jobs in the watchlist's companies.
+        Plus an `applied` count from this account's activity_log against
+        any company in the watchlist (case-insensitive on company display
+        name). Other activity types are not summarized here — the simple
+        "have I touched this?" signal is what the LLM needs to decide
+        which watchlist to drill into.
+        """
+        rows = self.conn.execute(
+            """
+            WITH lists AS (
+                SELECT id, slug, name, notes, filter, created_at, updated_at
+                  FROM watchlists
+                 WHERE account_id = %(account_id)s
+            ),
+            members AS (
+                SELECT wm.watchlist_id, wm.company_slug, c.name AS company_name
+                  FROM watchlist_members wm
+                  JOIN companies c ON c.slug = wm.company_slug
+                 WHERE wm.watchlist_id IN (SELECT id FROM lists)
+            ),
+            job_counts AS (
+                SELECT m.watchlist_id,
+                       COUNT(*) FILTER (
+                           WHERE j.listing_status = 'active'
+                       ) AS total_active,
+                       COUNT(*) FILTER (
+                           WHERE j.listing_status = 'active'
+                             AND j.effective_date >= (CURRENT_DATE - INTERVAL '1 day')
+                       ) AS posted_1d,
+                       COUNT(*) FILTER (
+                           WHERE j.listing_status = 'active'
+                             AND j.effective_date >= (CURRENT_DATE - INTERVAL '7 days')
+                       ) AS posted_7d,
+                       COUNT(*) FILTER (
+                           WHERE j.listing_status = 'active'
+                             AND j.effective_date >= (CURRENT_DATE - INTERVAL '30 days')
+                       ) AS posted_30d
+                  FROM members m
+                  JOIN jobs j ON j.company_slug = m.company_slug
+                 GROUP BY m.watchlist_id
+            ),
+            applied_counts AS (
+                SELECT m.watchlist_id, COUNT(*) AS applied
+                  FROM members m
+                  JOIN activity_log a
+                    ON lower(a.company) = lower(m.company_name)
+                   AND a.account_id = %(account_id)s
+                   AND a.action = 'Application'
+                 GROUP BY m.watchlist_id
+            )
+            SELECT l.*,
+                   COALESCE(jc.total_active, 0) AS total_active,
+                   COALESCE(jc.posted_1d, 0)    AS posted_1d,
+                   COALESCE(jc.posted_7d, 0)    AS posted_7d,
+                   COALESCE(jc.posted_30d, 0)   AS posted_30d,
+                   COALESCE(ac.applied, 0)      AS applied,
+                   ARRAY(
+                       SELECT company_slug FROM members
+                        WHERE watchlist_id = l.id
+                        ORDER BY company_slug
+                   ) AS companies
+              FROM lists l
+              LEFT JOIN job_counts jc ON jc.watchlist_id = l.id
+              LEFT JOIN applied_counts ac ON ac.watchlist_id = l.id
+             ORDER BY l.updated_at DESC
+            """,
+            {"account_id": account_id},
+        ).fetchall()
+
+        result = []
+        for r in rows:
+            base = self._watchlist_row(r, list(r["companies"]))
+            base["counts"] = {
+                "total_active": int(r["total_active"]),
+                "posted_1d": int(r["posted_1d"]),
+                "posted_7d": int(r["posted_7d"]),
+                "posted_30d": int(r["posted_30d"]),
+                "applied": int(r["applied"]),
+            }
+            result.append(base)
+        return result
+
+    # -------------------------------------------------------------------
     # CSV Migration
     # -------------------------------------------------------------------
 

--- a/tests/test_watchlists.py
+++ b/tests/test_watchlists.py
@@ -1,0 +1,293 @@
+"""Store-layer tests for watchlists.
+
+Cross-account isolation is the load-bearing invariant — one account's
+watchlists must never bleed into another's reads or counts.
+"""
+
+from datetime import date, timedelta
+
+import pytest
+
+from jobbuddy.core import merge_watchlist_defaults
+from jobbuddy.models import Account
+from jobbuddy.store import JobStore
+from tests.conftest import make_job
+
+
+def _other_account(store: JobStore) -> Account:
+    return store.upsert_account_from_claims(
+        "entra",
+        {
+            "oid": "00000000-0000-0000-0000-000000000002",
+            "sub": "test-subject-2",
+            "name": "Other User",
+        },
+    )
+
+
+class TestCreateAndGet:
+    def test_basic_create_returns_full_row(self, store: JobStore, test_account: Account):
+        row = store.create_watchlist(
+            test_account.id, slug="ai", name="AI focus",
+            filter={"query": "staff engineer"},
+            company_slugs=["acme", "beta"],
+            notes="track this",
+        )
+        assert row["slug"] == "ai"
+        assert row["name"] == "AI focus"
+        assert row["notes"] == "track this"
+        assert row["filter"] == {"query": "staff engineer"}
+        assert set(row["companies"]) == {"acme", "beta"}
+
+    def test_get_by_account_and_slug(self, store: JobStore, test_account: Account):
+        store.create_watchlist(test_account.id, slug="ai", name="AI focus")
+        wl = store.get_watchlist(test_account.id, "ai")
+        assert wl is not None
+        assert wl["slug"] == "ai"
+
+    def test_get_returns_none_for_missing(self, store: JobStore, test_account: Account):
+        assert store.get_watchlist(test_account.id, "nope") is None
+
+    def test_unknown_company_slug_is_silently_dropped(self, store: JobStore, test_account: Account):
+        row = store.create_watchlist(
+            test_account.id, slug="x", name="x",
+            company_slugs=["acme", "does-not-exist"],
+        )
+        assert row["companies"] == ["acme"]
+
+    def test_duplicate_slug_per_account_raises(self, store: JobStore, test_account: Account):
+        store.create_watchlist(test_account.id, slug="ai", name="AI")
+        with pytest.raises(ValueError, match="already exists"):
+            store.create_watchlist(test_account.id, slug="ai", name="AI v2")
+
+    def test_same_slug_different_accounts_is_allowed(self, store: JobStore, test_account: Account):
+        other = _other_account(store)
+        store.create_watchlist(test_account.id, slug="ai", name="A")
+        store.create_watchlist(other.id, slug="ai", name="B")
+        a = store.get_watchlist(test_account.id, "ai")
+        b = store.get_watchlist(other.id, "ai")
+        assert a is not None and a["name"] == "A"
+        assert b is not None and b["name"] == "B"
+
+
+class TestUpdate:
+    def test_update_metadata_only(self, store: JobStore, test_account: Account):
+        store.create_watchlist(test_account.id, slug="ai", name="AI")
+        row = store.update_watchlist(
+            test_account.id, "ai", name="AI v2", notes="updated",
+            filter={"query": "rust"},
+        )
+        assert row is not None
+        assert row["name"] == "AI v2"
+        assert row["notes"] == "updated"
+        assert row["filter"] == {"query": "rust"}
+
+    def test_add_and_remove_members(self, store: JobStore, test_account: Account):
+        store.create_watchlist(
+            test_account.id, slug="ai", name="AI",
+            company_slugs=["acme", "beta"],
+        )
+        row = store.update_watchlist(
+            test_account.id, "ai", add=["good"], remove=["acme"],
+        )
+        assert row is not None
+        assert set(row["companies"]) == {"beta", "good"}
+
+    def test_update_missing_returns_none(self, store: JobStore, test_account: Account):
+        assert store.update_watchlist(test_account.id, "nope", name="x") is None
+
+    def test_account_isolation_on_update(self, store: JobStore, test_account: Account):
+        other = _other_account(store)
+        store.create_watchlist(other.id, slug="ai", name="theirs")
+        # test_account tries to update the other account's watchlist — should miss
+        assert store.update_watchlist(test_account.id, "ai", name="hijack") is None
+        wl = store.get_watchlist(other.id, "ai")
+        assert wl is not None and wl["name"] == "theirs"
+
+
+class TestDelete:
+    def test_delete_returns_true(self, store: JobStore, test_account: Account):
+        store.create_watchlist(test_account.id, slug="ai", name="AI")
+        assert store.delete_watchlist(test_account.id, "ai") is True
+        assert store.get_watchlist(test_account.id, "ai") is None
+
+    def test_delete_missing_returns_false(self, store: JobStore, test_account: Account):
+        assert store.delete_watchlist(test_account.id, "nope") is False
+
+    def test_account_isolation_on_delete(self, store: JobStore, test_account: Account):
+        other = _other_account(store)
+        store.create_watchlist(other.id, slug="ai", name="theirs")
+        assert store.delete_watchlist(test_account.id, "ai") is False
+        assert store.get_watchlist(other.id, "ai") is not None
+
+
+class TestListWithCounts:
+    def test_empty_list_for_new_account(self, store: JobStore, test_account: Account):
+        assert store.list_watchlists(test_account.id) == []
+
+    def test_freshness_histogram(self, store: JobStore, test_account: Account, pg_conninfo):
+        today = date.today()
+        jobs = [
+            make_job(id="r1", title="recent",
+                     published_at=today,
+                     last_listing_update=today),
+            make_job(id="w1", title="this week",
+                     published_at=today - timedelta(days=5),
+                     last_listing_update=today - timedelta(days=5)),
+            make_job(id="m1", title="this month",
+                     published_at=today - timedelta(days=20),
+                     last_listing_update=today - timedelta(days=20)),
+            make_job(id="old", title="stale",
+                     published_at=today - timedelta(days=90),
+                     last_listing_update=today - timedelta(days=90)),
+        ]
+        store.upsert_jobs("acme", jobs)
+        store.create_watchlist(
+            test_account.id, slug="ai", name="AI",
+            company_slugs=["acme"],
+        )
+        rows = store.list_watchlists(test_account.id)
+        assert len(rows) == 1
+        counts = rows[0]["counts"]
+        assert counts["total_active"] == 4
+        # posted_1d catches today's job; the precise count depends on
+        # CURRENT_DATE math, but it must not exceed posted_7d.
+        assert counts["posted_1d"] >= 1
+        assert counts["posted_7d"] >= 2
+        assert counts["posted_7d"] <= counts["posted_30d"]
+        assert counts["posted_30d"] == 3
+
+    def test_applied_count(self, store: JobStore, test_account: Account):
+        store.create_watchlist(
+            test_account.id, slug="ai", name="AI",
+            company_slugs=["acme", "beta"],
+        )
+        # Two applications at acme (in-watchlist), one at workday-co (not).
+        store.append_activity(test_account.id, "Acme Corp", "Eng", "Application")
+        store.append_activity(test_account.id, "Acme Corp", "PM", "Application")
+        store.append_activity(test_account.id, "Workday Co", "Eng", "Application")
+        # Non-Application activity must not be counted.
+        store.append_activity(test_account.id, "Acme Corp", "Eng", "Screen")
+        rows = store.list_watchlists(test_account.id)
+        assert rows[0]["counts"]["applied"] == 2
+
+    def test_account_isolation_on_list(self, store: JobStore, test_account: Account):
+        other = _other_account(store)
+        store.create_watchlist(test_account.id, slug="mine", name="mine")
+        store.create_watchlist(other.id, slug="theirs", name="theirs")
+        mine = store.list_watchlists(test_account.id)
+        theirs = store.list_watchlists(other.id)
+        assert [r["slug"] for r in mine] == ["mine"]
+        assert [r["slug"] for r in theirs] == ["theirs"]
+
+
+class TestMergeDefaults:
+    def test_explicit_args_win(self):
+        wl = {
+            "filter": {"query": "rust", "posted_since": "7d"},
+            "companies": ["acme"],
+        }
+        q, ex, loc, since, comp = merge_watchlist_defaults(
+            wl, query="python", exclude_companies=None,
+            location="", posted_since="",
+        )
+        assert q == "python"  # caller overrode
+        assert since == "7d"  # watchlist filled it in
+        assert comp == ["acme"]
+
+    def test_caller_companies_override_watchlist(self):
+        wl = {"filter": {}, "companies": ["acme"]}
+        _, _, _, _, comp = merge_watchlist_defaults(
+            wl, query="", exclude_companies=None,
+            location="", posted_since="",
+            companies=["beta"],
+        )
+        assert comp == ["beta"]
+
+    def test_rejects_unknown_filter_keys(self):
+        wl = {"filter": {"bogus": 1}, "companies": []}
+        with pytest.raises(ValueError, match="unknown keys"):
+            merge_watchlist_defaults(
+                wl, query="", exclude_companies=None,
+                location="", posted_since="",
+            )
+
+
+class TestSearchJobsWatchlistIntegration:
+    """End-to-end through core.search_jobs: watchlist scopes companies and
+    layers in saved filters, while explicit caller args win."""
+
+    def test_scopes_to_watchlist_companies(self, store: JobStore, test_account: Account):
+        from jobbuddy.core import search_jobs
+
+        today = date.today()
+        store.upsert_jobs("acme", [make_job(id="a1", title="acme role", published_at=today)])
+        store.upsert_jobs("beta", [make_job(id="b1", title="beta role", published_at=today)])
+        store.upsert_jobs("good", [make_job(id="g1", title="good role", published_at=today)])
+        store.create_watchlist(
+            test_account.id, slug="mine", name="mine",
+            company_slugs=["acme", "beta"],
+        )
+        wl = store.get_watchlist(test_account.id, "mine")
+        assert wl is not None
+
+        from jobbuddy.core import merge_watchlist_defaults
+        q, ex, loc, since, comp = merge_watchlist_defaults(
+            wl, query="", exclude_companies=None, location="", posted_since="",
+        )
+        rows = search_jobs(query=q, companies=comp, exclude_companies=ex,
+                           location=loc, posted_since=since, limit=20)
+        slugs = {r.company_slug for r in rows}
+        assert slugs == {"acme", "beta"}  # `good` was not in the watchlist
+
+    def test_saved_filter_applies(self, store: JobStore, test_account: Account):
+        from jobbuddy.core import merge_watchlist_defaults, search_jobs
+
+        today = date.today()
+        store.upsert_jobs("acme", [
+            make_job(id="match", title="staff engineer",
+                     published_at=today, description="staff engineer role"),
+            make_job(id="miss", title="janitor",
+                     published_at=today, description="janitor"),
+        ])
+        store.create_watchlist(
+            test_account.id, slug="se", name="se",
+            company_slugs=["acme"],
+            filter={"query": "engineer"},
+        )
+        wl = store.get_watchlist(test_account.id, "se")
+        q, ex, loc, since, comp = merge_watchlist_defaults(
+            wl, query="", exclude_companies=None, location="", posted_since="",
+        )
+        rows = search_jobs(query=q, companies=comp, exclude_companies=ex,
+                           location=loc, posted_since=since, limit=20)
+        ids = {r.job_id for r in rows}
+        assert "match" in ids
+        assert "miss" not in ids
+
+    def test_explicit_query_overrides_saved(self, store: JobStore, test_account: Account):
+        from jobbuddy.core import merge_watchlist_defaults, search_jobs
+
+        today = date.today()
+        store.upsert_jobs("acme", [
+            make_job(id="rust", title="rust engineer",
+                     published_at=today, description="rust"),
+            make_job(id="python", title="python engineer",
+                     published_at=today, description="python"),
+        ])
+        store.create_watchlist(
+            test_account.id, slug="se", name="se",
+            company_slugs=["acme"],
+            filter={"query": "rust"},
+        )
+        wl = store.get_watchlist(test_account.id, "se")
+        q, ex, loc, since, comp = merge_watchlist_defaults(
+            wl, query="python",  # caller override
+            exclude_companies=None, location="", posted_since="",
+        )
+        assert q == "python"
+        rows = search_jobs(query=q, companies=comp, exclude_companies=ex,
+                           location=loc, posted_since=since, limit=20)
+        ids = {r.job_id for r in rows}
+        assert "python" in ids
+        assert "rust" not in ids


### PR DESCRIPTION
## Summary

Implements **watchlists** — account-scoped saved searches that survive session boundaries. A watchlist is a saved-search *definition* (companies + filter defaults), not a job list; jobs come from `search_jobs(watchlist=<slug>)`.

Four new MCP tools: `watchlist_create`, `watchlist_update`, `watchlist_delete`, `watchlist_list`. `search_jobs` gains a `watchlist=<slug>` parameter that layers the saved companies + filters under explicit caller args (caller wins).

`watchlist_list` returns inventory only with precomputed summary counts — no job listings, no parameters. Counts include a freshness histogram (`posted_1d` / `posted_7d` / `posted_30d`) plus `total_active` and `applied`. The histogram windows against `effective_date` (the generated `COALESCE(last_listing_update, published_at)` column from migration 019) so ATS-side re-publish dates count as fresh.

## Cory's review-comment direction

- **FK target**: `companies.slug` is itself the TEXT PRIMARY KEY of `companies`, so `watchlist_members.company_slug` FKs directly to it. No surrogate id needed.
- **Exclude non-active**: every count filters `listing_status = 'active'`.
- **1d/7d/30d summary**: histogram in place of a single number, so a "heavy company" watchlist still tells you whether anything new dropped today.
- **update_since / published**: counts use `effective_date`, not `published_at`.

## Schema (migration 020)

- `watchlists` — `(id uuidv7, account_id → accounts(id) CASCADE, slug, name, notes, filter jsonb, …)`, `UNIQUE (account_id, slug)`.
- `watchlist_members` — junction on `(watchlist_id, company_slug)`. `CASCADE` both ways: deleting a company prunes the membership; deleting a watchlist prunes its roster.

## Tests

23 new tests covering store CRUD, account isolation (one account can't read/update/delete another's watchlist or have its counts), the freshness histogram, the applied-count rollup (Application-only, non-Application excluded), and the end-to-end `search_jobs(watchlist=…)` integration through `core.search_jobs`. Full suite passes 510/510.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)