### PR TITLE
fetchers: wire faucet config into Uber + enable with engineering filter

### DIFF
--- a/src/jobbuddy/fetchers/uber.py
+++ b/src/jobbuddy/fetchers/uber.py
@@ -57,8 +57,21 @@ class UberFetcher(ATSFetcher):
     descriptions_in_listing = True
     enrich_delay = 0.0
 
-    def __init__(self, board: str, name: str | None = None):
+    def __init__(
+        self,
+        board: str,
+        name: str | None = None,
+        *,
+        selected_fields: dict | None = None,
+    ):
         super().__init__(board, name or "Uber")
+        # Faucet config. Uber's POST API accepts top-level filter arrays under
+        # `params`: OR-within-key, AND-across-keys. Empty arrays = unfiltered.
+        # Plumbed from the company registry via `**kw` in fetchers.__init__.
+        fields = selected_fields or {}
+        self._departments = list(fields.get("department") or [])
+        self._teams = list(fields.get("team") or [])
+        self._locations = list(fields.get("location") or [])
         self.client.headers.update({
             "content-type": "application/json",
             "x-csrf-token": "x",
@@ -71,7 +84,13 @@ class UberFetcher(ATSFetcher):
         *,
         on_retry: RetryCallback | None = None,
     ) -> dict:
-        payload: dict = {"params": {"location": [], "department": [], "team": []}}
+        payload: dict = {
+            "params": {
+                "location": self._locations,
+                "department": self._departments,
+                "team": self._teams,
+            }
+        }
         if offset:
             payload["offset"] = offset
 

--- a/src/jobbuddy/migrations/021_uber_company.sql
+++ b/src/jobbuddy/migrations/021_uber_company.sql
@@ -1,0 +1,24 @@
+-- Enable the `uber` company (row already exists with ats=NULL, config='{}').
+--
+-- Uber publishes a large unsegmented catalog via a single global board, so
+-- registering it without a faucet would pull ~1k listings per sync. Apply
+-- an engineering-shaped department filter at the fetcher boundary — the
+-- Uber API ORs within `department` and ANDs across keys. `team`/`location`
+-- stay empty: jsb is an evidence provider, the LLM does the ranking, so
+-- over-narrowing here would hide candidates the ranker could still use.
+--
+-- The `board` value is documented as ignored by UberFetcher (single global
+-- board); we set it to 'uber' as a stable placeholder.
+--
+-- Additive jsonb merge (`||`) — re-running this migration is a no-op
+-- because the same key/value pair just overwrites itself.
+
+UPDATE companies SET
+  ats = 'uber',
+  board = 'uber',
+  config = config || jsonb_build_object(
+    'selected_fields', jsonb_build_object(
+      'department', jsonb_build_array('Engineering', 'Data Science', 'Product')
+    )
+  )
+WHERE slug = 'uber';

--- a/tests/test_uber.py
+++ b/tests/test_uber.py
@@ -158,6 +158,57 @@ class TestUberFetcherInit:
         f = UberFetcher("uber", "Uber Technologies")
         assert f.name == "Uber Technologies"
 
+    def test_default_filters_are_empty(self):
+        f = UberFetcher("uber")
+        assert f._departments == []
+        assert f._teams == []
+        assert f._locations == []
+
+    def test_selected_fields_populates_filters(self):
+        f = UberFetcher(
+            "uber",
+            selected_fields={
+                "department": ["Engineering", "Data Science"],
+                "team": ["Maps"],
+                "location": ["San Francisco"],
+            },
+        )
+        assert f._departments == ["Engineering", "Data Science"]
+        assert f._teams == ["Maps"]
+        assert f._locations == ["San Francisco"]
+
+
+# ---------------------------------------------------------------------------
+# Faucet wiring — request body must reflect configured filters
+# ---------------------------------------------------------------------------
+
+
+class TestFaucetWiring:
+    def test_default_sends_empty_arrays(self):
+        """Backwards-compat: no config -> three empty arrays, byte-identical to prior behavior."""
+        fetcher = _make_fetcher()
+        _mock_post(fetcher, SINGLE_PAGE_RESPONSE)
+        fetcher.list_jobs()
+
+        call = fetcher.client.post.call_args_list[0]
+        payload = call.kwargs.get("json") or call.args[1]
+        assert payload == {"params": {"location": [], "department": [], "team": []}}
+
+    def test_selected_fields_sent_in_body(self):
+        fetcher = UberFetcher(
+            "uber",
+            selected_fields={"department": ["Engineering", "Data Science", "Product"]},
+        )
+        fetcher.client = MagicMock()
+        _mock_post(fetcher, SINGLE_PAGE_RESPONSE)
+        fetcher.list_jobs()
+
+        call = fetcher.client.post.call_args_list[0]
+        payload = call.kwargs.get("json") or call.args[1]
+        assert payload["params"]["department"] == ["Engineering", "Data Science", "Product"]
+        assert payload["params"]["team"] == []
+        assert payload["params"]["location"] == []
+
 
 # ---------------------------------------------------------------------------
 # list_jobs


### PR DESCRIPTION
## Why

Uber publishes a large unsegmented catalog through a single global board (close to 1k active reqs in one page). The Uber fetcher (added in #64) sends three hardcoded empty filter arrays in its POST body, so registering Uber as-is would pull the full catalog every sync. Large-employer ATSes need faucet-shaped narrowing at the fetcher boundary — same pattern as `selected_fields` (Phenom) and `default_filters` (Eightfold) introduced in migration 017.

## What changed

**Fetcher (`src/jobbuddy/fetchers/uber.py`)**
- `__init__` now accepts `selected_fields={"department": [...], "team": [...], "location": [...]}` and forwards each list into `params` on the POST body.
- Empty config is byte-identical to the prior behavior — three empty arrays — so existing companies / pagination paths are unaffected.

**Migration (`src/jobbuddy/migrations/021_uber_company.sql`)**
- Flips the existing `uber` row (created with `ats=NULL`, `config='{}'`): sets `ats='uber'`, `board='uber'` (UberFetcher docstring documents `board` as ignored — single global board), and merges a `selected_fields.department` faucet of `["Engineering", "Data Science", "Product"]` via additive `jsonb ||`. Re-runs are no-ops.
- `team` and `location` stay empty: jsb is an evidence provider; the calling LLM does the ranking; over-narrowing at the fetcher would hide candidates the ranker could otherwise use.

**Tests (`tests/test_uber.py`)**
- Defaults: confirms an unconfigured fetcher still sends `{"location": [], "department": [], "team": []}`.
- Faucet wiring: confirms `selected_fields.department` lands in the POST body's `params.department`.

## Verification

All 575 tests pass (`uv run pytest tests/`).

Live fetch through the configured path:

```
total=371
   299 Engineering
    51 Data Science
    21 Product
```

Matches the filter exactly — only the three target departments come back, totals consistent with the unfiltered department breakdown.

## Migration safety

Additive `jsonb ||` merge against a single row that already exists. Idempotent: a re-run overwrites the same key with the same value. Not applied to any environment as part of this PR — `jsb migrate` is the operator's call.