### PR TITLE
fetchers: fix Taleo listing parser, portal discovery, tz header + add faucet config

### DIFF
--- a/src/jobbuddy/fetchers/taleo.py
+++ b/src/jobbuddy/fetchers/taleo.py
@@ -6,6 +6,14 @@ that is embedded in the `jobsearch.ftl` page source — this fetcher discovers
 it automatically on the first `list_jobs()` call. Set `taleo_portal` in the
 company registry to skip auto-discovery.
 
+The listing endpoint returns rows whose visible cells live under `column[]`:
+`column[0]` is the title, `column[1]` is a JSON-encoded list of locations,
+`column[2]` is the posted-date string (free-form per tenant — `MM/DD/YYYY`
+on some, `Month DD, YYYY` on others; `dateutil.parser` handles both). The
+external job identifier is `contestNo` (the human-facing requisition number)
+with `jobId` as fallback when `contestNo` is absent. The job-field /
+department facet is not in the listing payload and is left None.
+
 Job descriptions are not included in the listing response; the enrich phase
 fetches them individually from the detail page.
 
@@ -14,9 +22,13 @@ Company registry fields:
   - board: subdomain prefix (e.g. "textron" for textron.taleo.net)
   - taleo_section: career section path component (e.g. "textron", "2")
   - taleo_portal: portal ID (optional; auto-discovered from jobsearch.ftl if absent)
+  - taleo_filters: optional dict mapping facet id (e.g. "JOB_FIELD",
+    "LOCATION", "ORGANIZATION") to a list of server-side facet value ids.
+    Empty / absent → unfiltered listing.
 """
 
 import copy
+import json
 import logging
 import re
 import threading
@@ -122,10 +134,12 @@ class TaleoFetcher(ATSFetcher):
         *,
         taleo_section: str = "",
         taleo_portal: str = "",
+        taleo_filters: dict[str, list[str]] | None = None,
     ):
         super().__init__(board, name)
         self.taleo_section = taleo_section or board
         self.taleo_portal = taleo_portal
+        self.taleo_filters = taleo_filters or {}
         self._portal_id: str | None = taleo_portal or None
         self._portal_lock = threading.Lock()
 
@@ -150,12 +164,18 @@ class TaleoFetcher(ATSFetcher):
         resp.raise_for_status()
         html = resp.text
 
-        # Pattern 1: embedded in a REST API URL reference (most reliable)
+        # Pattern 1: locallogoutservlet.jss reference (present on live tenants).
+        # Appears multiple times per page as `locallogoutservlet.jss?portal=NNN&portalCode=...`.
+        m = re.search(r"locallogoutservlet\.jss\?portal=(\d+)", html)
+        if m:
+            return m.group(1)
+
+        # Pattern 2: embedded in a REST API URL reference
         m = re.search(r"rest/jobboard/searchjobs[^\"']*portal=([A-Za-z0-9_-]+)", html)
         if m:
             return m.group(1)
 
-        # Pattern 2: JSON/JS variable with key "portal" or "portalId"
+        # Pattern 3: JSON/JS variable with key "portal" or "portalId"
         m = re.search(r"""['"](portal|portalId)['"]\s*[=:]\s*['"](\d+)['"]""", html)
         if m:
             return m.group(2)
@@ -183,20 +203,45 @@ class TaleoFetcher(ATSFetcher):
     def _list_body(self, page: int) -> dict:
         body = copy.deepcopy(_LIST_BODY_TEMPLATE)
         body["pageNo"] = page
+        if self.taleo_filters:
+            for bucket in body["filterSelectionParam"]["searchFilterSelections"]:
+                values = self.taleo_filters.get(bucket["id"])
+                if values:
+                    bucket["selectedValues"] = list(values)
         return body
 
+    def _parse_location(self, raw: str) -> str:
+        """Decode `column[1]` — a JSON-encoded list string like `["US-Texas-Fort Worth"]`."""
+        if not raw:
+            return ""
+        stripped = raw.strip()
+        if stripped.startswith("["):
+            try:
+                values = json.loads(stripped)
+            except (ValueError, TypeError):
+                return stripped
+            if isinstance(values, list):
+                parts = [str(v).strip() for v in values if v]
+                return "; ".join(parts)
+            return str(values)
+        return stripped
+
     def _parse_requisition(self, item: dict) -> Job | None:
-        """Parse one requisition dict from the REST response."""
+        """Parse one requisition dict from the REST response.
+
+        Live shape (verified against Textron + AAR Corp tenants):
+            {"jobId": "...", "contestNo": "...",
+             "column": [title, locations_json, posted_date, ...], ...}
+        """
         job_id = str(item.get("contestNo") or item.get("jobId") or "")
         if not job_id:
             return None
-        title = item.get("requisitionTitle") or item.get("jobTitle") or ""
-        location = item.get("primaryLocation") or item.get("location") or ""
-        department = item.get("jobField") or item.get("department") or None
 
-        dates = item.get("dates", {}) if isinstance(item.get("dates"), dict) else {}
-        raw_date = dates.get("openingDate") or item.get("postingDate")
-        published_at = _parse_date(raw_date)
+        columns = item.get("column") or []
+        title = str(columns[0]) if len(columns) > 0 and columns[0] else ""
+        location = self._parse_location(str(columns[1])) if len(columns) > 1 and columns[1] else ""
+        raw_date = str(columns[2]) if len(columns) > 2 and columns[2] else ""
+        published_at = _parse_date(raw_date) if raw_date else None
 
         url = self._detail_url(job_id)
         return Job(
@@ -206,7 +251,7 @@ class TaleoFetcher(ATSFetcher):
             url=url,
             apply_url=url,
             published_at=published_at,
-            department=department or None,
+            department=None,
         )
 
     def _fetch_page(
@@ -218,15 +263,19 @@ class TaleoFetcher(ATSFetcher):
     ) -> tuple[list[Job], int]:
         url = self._search_url(portal_id)
         body = self._list_body(page)
+        # The tz header is required: tenants return HTTP 500 without it. Any
+        # non-empty value is accepted; the browser sends an offset like "-480".
+        headers = {"tz": "0"}
 
         def _do():
-            resp = self.client.post(url, json=body)
+            resp = self.client.post(url, json=body, headers=headers)
             resp.raise_for_status()
             return resp.json()
 
         data = self._retry_request(_do, on_retry=on_retry)
         reqs = data.get("requisitionList", [])
-        total = data.get("requisitionCount", len(reqs))
+        paging = data.get("pagingData") or {}
+        total = paging.get("totalCount", len(reqs))
 
         jobs = [j for j in (self._parse_requisition(r) for r in reqs) if j is not None]
         return jobs, total

--- a/tests/test_taleo.py
+++ b/tests/test_taleo.py
@@ -1,4 +1,19 @@
-"""Tests for Oracle Taleo Enterprise ATS fetcher."""
+"""Tests for Oracle Taleo Enterprise ATS fetcher.
+
+Fixtures match the live response shape verified against the two known
+tenants (Textron Aviation at textron.taleo.net and AAR Corp at
+aarcorp.taleo.net):
+
+  - Requisition rows expose visible cells under `column[]` — `column[0]`
+    is the title, `column[1]` is a JSON-encoded list of locations,
+    `column[2]` is the posted-date string (free-form per tenant).
+  - The external job identifier is `contestNo` with `jobId` as fallback.
+  - The total-count value lives under `pagingData.totalCount`.
+  - The portal id appears in the `jobsearch.ftl` HTML as
+    `locallogoutservlet.jss?portal=NNN&portalCode=...`.
+  - The listing POST requires a `tz` header — tenants return HTTP 500
+    without it.
+"""
 
 from datetime import date
 from unittest.mock import MagicMock
@@ -13,7 +28,19 @@ from jobbuddy.url import parse_url
 # HTML fixtures
 # ---------------------------------------------------------------------------
 
-FTL_HTML_WITH_PORTAL = """\
+FTL_HTML_LOCALLOGOUT = """\
+<html>
+<head><title>Textron Aviation - Job Search</title></head>
+<body>
+<script>
+window.location.href = "/careersection/locallogoutservlet.jss?portal=8140753014&portalCode=TX";
+</script>
+<a href="/careersection/locallogoutservlet.jss?portal=8140753014&portalCode=TX2">Logout</a>
+</body>
+</html>
+"""
+
+FTL_HTML_REST_URL = """\
 <html>
 <head><title>Textron Aviation - Job Search</title></head>
 <body>
@@ -24,7 +51,7 @@ var jobSearchUrl = "/careersection/rest/jobboard/searchjobs?lang=en&portal=21404
 </html>
 """
 
-FTL_HTML_WITH_PORTAL_VAR = """\
+FTL_HTML_PORTAL_VAR = """\
 <html>
 <body>
 <script>
@@ -39,23 +66,6 @@ var config = {
 
 FTL_HTML_NO_PORTAL = """\
 <html><body><p>Job search page</p></body></html>
-"""
-
-DETAIL_HTML_NESTED = """\
-<html>
-<body>
-<div class="job-description">
-  <div class="section-header">Responsibilities</div>
-  <div class="section-body">
-    <ul><li>Design systems</li><li>Review code</li></ul>
-  </div>
-  <div class="section-header">Requirements</div>
-  <div class="section-body">
-    <p>5+ years experience</p>
-  </div>
-</div>
-</body>
-</html>
 """
 
 DETAIL_HTML_DIV = """\
@@ -85,59 +95,101 @@ DETAIL_HTML_REQUISITION = """\
 </html>
 """
 
+DETAIL_HTML_NESTED = """\
+<html>
+<body>
+<div class="job-description">
+  <div class="section-header">Responsibilities</div>
+  <div class="section-body">
+    <ul><li>Design systems</li><li>Review code</li></ul>
+  </div>
+  <div class="section-header">Requirements</div>
+  <div class="section-body">
+    <p>5+ years experience</p>
+  </div>
+</div>
+</body>
+</html>
+"""
+
 DETAIL_HTML_NO_DESCRIPTION = """\
 <html><body><p>Detailed job info here without proper markers</p></body></html>
 """
 
 
 # ---------------------------------------------------------------------------
-# Sample REST API responses
+# Sample REST API responses (live shape)
 # ---------------------------------------------------------------------------
 
+# Textron-style date format: MM/DD/YYYY.
 PAGE_1_RESPONSE = {
     "requisitionList": [
         {
-            "contestNo": "2026-TECH-001",
-            "requisitionTitle": "Aircraft Systems Engineer",
-            "primaryLocation": "Wichita, KS",
-            "jobField": "Engineering",
-            "dates": {"openingDate": "Apr 01, 2026", "closingDate": None},
+            "jobId": "1536952",
+            "contestNo": "341267",
+            "hotJob": False,
+            "alreadyAppliedOn": False,
+            "column": [
+                "Turning Mach Opr - 1st Shift MTC",
+                "[\"US-Texas-Fort Worth\"]",
+                "05/13/2026",
+            ],
+            "linkedColumn": 0,
+            "locationsColumns": [1],
         },
         {
-            "contestNo": "2026-TECH-002",
-            "requisitionTitle": "Software Engineer",
-            "primaryLocation": "Dallas, TX",
-            "jobField": "IT",
-            "dates": {"openingDate": "Mar 15, 2026"},
+            "jobId": "1536953",
+            "contestNo": "341268",
+            "column": [
+                "Aircraft Systems Engineer",
+                "[\"US-Kansas-Wichita\"]",
+                "04/01/2026",
+            ],
         },
     ],
-    "requisitionCount": 3,
+    "pagingData": {"totalCount": 3},
 }
 
+# AAR-style date format: "Month DD, YYYY".
 PAGE_2_RESPONSE = {
     "requisitionList": [
         {
-            "contestNo": "2026-TECH-003",
-            "requisitionTitle": "Supply Chain Analyst",
-            "primaryLocation": "Wichita, KS",
-            "jobField": "Operations",
-            "dates": {"openingDate": "Apr 22, 2026"},
+            "jobId": "1536954",
+            "contestNo": "341269",
+            "column": [
+                "Supply Chain Analyst",
+                "[\"US-Illinois-Wood Dale\"]",
+                "April 22, 2026",
+            ],
         },
     ],
-    "requisitionCount": 3,
+    "pagingData": {"totalCount": 3},
 }
 
 SINGLE_PAGE_RESPONSE = {
     "requisitionList": [
         {
-            "contestNo": "2026-TECH-001",
-            "requisitionTitle": "Aircraft Systems Engineer",
-            "primaryLocation": "Wichita, KS",
-            "jobField": "Engineering",
-            "dates": {"openingDate": "Apr 01, 2026", "closingDate": None},
+            "jobId": "1536952",
+            "contestNo": "341267",
+            "column": [
+                "Aircraft Systems Engineer",
+                "[\"US-Texas-Fort Worth\"]",
+                "05/13/2026",
+            ],
         },
     ],
-    "requisitionCount": 1,
+    "pagingData": {"totalCount": 1},
+}
+
+# Requisition with no contestNo — must fall back to jobId.
+JOB_ID_ONLY_RESPONSE = {
+    "requisitionList": [
+        {
+            "jobId": "99999",
+            "column": ["MRO Specialist", "[\"US-Texas-Dallas\"]", "03/15/2026"],
+        },
+    ],
+    "pagingData": {"totalCount": 1},
 }
 
 
@@ -146,8 +198,18 @@ SINGLE_PAGE_RESPONSE = {
 # ---------------------------------------------------------------------------
 
 
-def _make_fetcher(board: str = "textron", section: str = "textron") -> TaleoFetcher:
-    fetcher = TaleoFetcher(board, "Textron Aviation", taleo_section=section)
+def _make_fetcher(
+    board: str = "textron",
+    section: str = "textron",
+    *,
+    taleo_filters: dict[str, list[str]] | None = None,
+) -> TaleoFetcher:
+    fetcher = TaleoFetcher(
+        board,
+        "Textron Aviation",
+        taleo_section=section,
+        taleo_filters=taleo_filters,
+    )
     fetcher.client = MagicMock()
     return fetcher
 
@@ -160,25 +222,20 @@ def _mock_get(fetcher: TaleoFetcher, html: str) -> MagicMock:
     return resp
 
 
-def _mock_post(fetcher: TaleoFetcher, response_json: dict) -> MagicMock:
-    resp = MagicMock()
-    resp.json.return_value = response_json
-    resp.raise_for_status = MagicMock()
-    fetcher.client.post.return_value = resp
-    return resp
-
-
 # ---------------------------------------------------------------------------
 # Date parsing
 # ---------------------------------------------------------------------------
 
 
 class TestParseDate:
-    def test_standard_long_date(self):
-        assert _parse_date("Apr 01, 2026") == date(2026, 4, 1)
+    def test_textron_slash_date(self):
+        assert _parse_date("05/13/2026") == date(2026, 5, 13)
 
-    def test_slash_date(self):
-        assert _parse_date("04/01/2026") == date(2026, 4, 1)
+    def test_aar_long_date(self):
+        assert _parse_date("April 22, 2026") == date(2026, 4, 22)
+
+    def test_short_month(self):
+        assert _parse_date("Apr 01, 2026") == date(2026, 4, 1)
 
     def test_iso_date(self):
         assert _parse_date("2026-04-01") == date(2026, 4, 1)
@@ -199,17 +256,21 @@ class TestParseDate:
 
 
 class TestPortalDiscovery:
+    def test_discovers_from_locallogoutservlet(self):
+        """Live tenants expose the portal id via locallogoutservlet.jss."""
+        fetcher = _make_fetcher()
+        _mock_get(fetcher, FTL_HTML_LOCALLOGOUT)
+        assert fetcher._get_portal_id() == "8140753014"
+
     def test_discovers_from_rest_url(self):
         fetcher = _make_fetcher()
-        _mock_get(fetcher, FTL_HTML_WITH_PORTAL)
-        portal_id = fetcher._get_portal_id()
-        assert portal_id == "2140452562"
+        _mock_get(fetcher, FTL_HTML_REST_URL)
+        assert fetcher._get_portal_id() == "2140452562"
 
     def test_discovers_from_js_variable(self):
         fetcher = _make_fetcher()
-        _mock_get(fetcher, FTL_HTML_WITH_PORTAL_VAR)
-        portal_id = fetcher._get_portal_id()
-        assert portal_id == "9876543210"
+        _mock_get(fetcher, FTL_HTML_PORTAL_VAR)
+        assert fetcher._get_portal_id() == "9876543210"
 
     def test_raises_when_not_found(self):
         fetcher = _make_fetcher()
@@ -220,21 +281,19 @@ class TestPortalDiscovery:
     def test_portal_override_skips_discovery(self):
         fetcher = TaleoFetcher("textron", taleo_section="textron", taleo_portal="STATIC123")
         fetcher.client = MagicMock()
-        portal_id = fetcher._get_portal_id()
-        assert portal_id == "STATIC123"
+        assert fetcher._get_portal_id() == "STATIC123"
         fetcher.client.get.assert_not_called()
 
     def test_caches_portal_id(self):
         fetcher = _make_fetcher()
-        _mock_get(fetcher, FTL_HTML_WITH_PORTAL)
+        _mock_get(fetcher, FTL_HTML_LOCALLOGOUT)
         fetcher._get_portal_id()
         fetcher._get_portal_id()
-        # Should only fetch the FTL page once
         assert fetcher.client.get.call_count == 1
 
     def test_uses_taleo_section_in_ftl_url(self):
         fetcher = _make_fetcher(board="aarcorp", section="2")
-        _mock_get(fetcher, FTL_HTML_WITH_PORTAL)
+        _mock_get(fetcher, FTL_HTML_LOCALLOGOUT)
         fetcher._get_portal_id()
         called_url = fetcher.client.get.call_args[0][0]
         assert "aarcorp.taleo.net" in called_url
@@ -242,7 +301,7 @@ class TestPortalDiscovery:
 
 
 # ---------------------------------------------------------------------------
-# Requisition parsing
+# Requisition parsing — live `column[]` shape
 # ---------------------------------------------------------------------------
 
 
@@ -250,51 +309,88 @@ class TestRequisitionParsing:
     def test_full_requisition(self):
         fetcher = _make_fetcher()
         item = {
-            "contestNo": "2026-TECH-001",
-            "requisitionTitle": "Aircraft Systems Engineer",
-            "primaryLocation": "Wichita, KS",
-            "jobField": "Engineering",
-            "dates": {"openingDate": "Apr 01, 2026"},
+            "jobId": "1536952",
+            "contestNo": "341267",
+            "column": [
+                "Aircraft Systems Engineer",
+                "[\"US-Kansas-Wichita\"]",
+                "05/13/2026",
+            ],
         }
         job = fetcher._parse_requisition(item)
         assert job is not None
-        assert job.id == "2026-TECH-001"
+        assert job.id == "341267"  # contestNo, not jobId
         assert job.title == "Aircraft Systems Engineer"
-        assert job.location == "Wichita, KS"
-        assert job.department == "Engineering"
-        assert job.published_at == date(2026, 4, 1)
+        assert job.location == "US-Kansas-Wichita"
+        assert job.department is None  # listing payload doesn't carry job-field
+        assert job.published_at == date(2026, 5, 13)
         assert "jobdetail.ftl" in job.url
-        assert "job=2026-TECH-001" in job.url
+        assert "job=341267" in job.url
 
-    def test_alternate_field_names(self):
+    def test_aar_style_date_format(self):
+        """AAR Corp tenant uses `Month DD, YYYY`; dateutil handles both."""
         fetcher = _make_fetcher()
         item = {
-            "jobId": 99999,
-            "jobTitle": "MRO Specialist",
-            "location": "Dallas, TX",
-            "postingDate": "2026-03-15",
+            "jobId": "1",
+            "contestNo": "AAR-1",
+            "column": ["Tech", "[\"US-IL-Wood Dale\"]", "April 22, 2026"],
+        }
+        job = fetcher._parse_requisition(item)
+        assert job.published_at == date(2026, 4, 22)
+
+    def test_falls_back_to_job_id_when_no_contest_no(self):
+        fetcher = _make_fetcher()
+        item = {
+            "jobId": "99999",
+            "column": ["MRO Specialist", "[\"US-TX-Dallas\"]", "03/15/2026"],
         }
         job = fetcher._parse_requisition(item)
         assert job is not None
         assert job.id == "99999"
-        assert job.title == "MRO Specialist"
+
+    def test_multi_location_joined(self):
+        fetcher = _make_fetcher()
+        item = {
+            "contestNo": "x",
+            "column": ["Engineer", "[\"US-TX-Dallas\", \"US-KS-Wichita\"]", ""],
+        }
+        job = fetcher._parse_requisition(item)
+        assert "US-TX-Dallas" in job.location
+        assert "US-KS-Wichita" in job.location
+
+    def test_unparseable_location_string_kept_as_is(self):
+        fetcher = _make_fetcher()
+        item = {
+            "contestNo": "x",
+            "column": ["Engineer", "Dallas, TX", ""],
+        }
+        job = fetcher._parse_requisition(item)
         assert job.location == "Dallas, TX"
-        assert job.published_at == date(2026, 3, 15)
 
     def test_no_id_returns_none(self):
         fetcher = _make_fetcher()
-        job = fetcher._parse_requisition({"requisitionTitle": "Engineer"})
+        job = fetcher._parse_requisition({"column": ["Engineer", "", ""]})
         assert job is None
+
+    def test_missing_column_fields_tolerated(self):
+        fetcher = _make_fetcher()
+        item = {"contestNo": "x", "column": []}
+        job = fetcher._parse_requisition(item)
+        assert job is not None
+        assert job.title == ""
+        assert job.location == ""
+        assert job.published_at is None
 
     def test_url_encodes_section(self):
         fetcher = _make_fetcher(board="aarcorp", section="2")
-        item = {"contestNo": "123", "requisitionTitle": "Test", "primaryLocation": ""}
+        item = {"contestNo": "123", "column": ["Test", "", ""]}
         job = fetcher._parse_requisition(item)
         assert "/careersection/2/jobdetail.ftl" in job.url
 
 
 # ---------------------------------------------------------------------------
-# Description extraction
+# Description extraction (listing-page-side fixtures only; live detail-page
+# extraction is tracked separately — see follow-up issue.)
 # ---------------------------------------------------------------------------
 
 
@@ -318,7 +414,6 @@ class TestDescriptionExtraction:
         assert desc is None
 
     def test_nested_divs_fully_extracted(self):
-        """Depth-counting should capture all nested sections, not just the first div."""
         fetcher = _make_fetcher()
         desc = fetcher._extract_description(DETAIL_HTML_NESTED)
         assert desc is not None
@@ -334,9 +429,8 @@ class TestDescriptionExtraction:
 
 class TestListJobs:
     def _setup_list(self, fetcher: TaleoFetcher, page_responses: list[dict]) -> None:
-        """Wire up a fetcher: first GET for portal discovery, then POSTs for pages."""
         get_resp = MagicMock()
-        get_resp.text = FTL_HTML_WITH_PORTAL
+        get_resp.text = FTL_HTML_LOCALLOGOUT
         get_resp.raise_for_status = MagicMock()
         fetcher.client.get.return_value = get_resp
 
@@ -351,45 +445,117 @@ class TestListJobs:
     def test_single_page(self):
         fetcher = _make_fetcher()
         self._setup_list(fetcher, [SINGLE_PAGE_RESPONSE])
-
         jobs = fetcher.list_jobs()
         assert len(jobs) == 1
-        assert jobs[0].id == "2026-TECH-001"
+        assert jobs[0].id == "341267"
         assert jobs[0].title == "Aircraft Systems Engineer"
+        assert jobs[0].location == "US-Texas-Fort Worth"
+        assert jobs[0].published_at == date(2026, 5, 13)
 
-    def test_pagination(self):
+    def test_pagination_uses_total_count(self):
+        """Pagination loops while jobs collected < pagingData.totalCount."""
         fetcher = _make_fetcher()
         self._setup_list(fetcher, [PAGE_1_RESPONSE, PAGE_2_RESPONSE])
-
         jobs = fetcher.list_jobs()
         assert len(jobs) == 3
         ids = {j.id for j in jobs}
-        assert "2026-TECH-001" in ids
-        assert "2026-TECH-003" in ids
+        assert "341267" in ids
+        assert "341269" in ids
 
     def test_rest_endpoint_includes_portal(self):
         fetcher = _make_fetcher()
         self._setup_list(fetcher, [SINGLE_PAGE_RESPONSE])
         fetcher.list_jobs()
         called_url = fetcher.client.post.call_args[0][0]
-        assert "portal=2140452562" in called_url
+        assert "portal=8140753014" in called_url
+
+    def test_tz_header_is_sent(self):
+        """Without a `tz` header, live tenants return HTTP 500."""
+        fetcher = _make_fetcher()
+        self._setup_list(fetcher, [SINGLE_PAGE_RESPONSE])
+        fetcher.list_jobs()
+        kwargs = fetcher.client.post.call_args.kwargs
+        headers = kwargs.get("headers") or {}
+        assert "tz" in headers
+        assert headers["tz"]  # non-empty
 
     def test_page_body_increments(self):
         fetcher = _make_fetcher()
         self._setup_list(fetcher, [PAGE_1_RESPONSE, PAGE_2_RESPONSE])
         fetcher.list_jobs()
-
-        first_body = fetcher.client.post.call_args_list[0].kwargs.get("json") or \
-            fetcher.client.post.call_args_list[0].args[1]
+        first_body = fetcher.client.post.call_args_list[0].kwargs.get("json")
+        second_body = fetcher.client.post.call_args_list[1].kwargs.get("json")
         assert first_body["pageNo"] == 1
+        assert second_body["pageNo"] == 2
 
     def test_progress_callback(self):
         fetcher = _make_fetcher()
         self._setup_list(fetcher, [SINGLE_PAGE_RESPONSE])
-
         calls = []
         fetcher.list_jobs(on_progress=lambda f, t: calls.append((f, t)))
         assert calls[-1] == (1, 1)
+
+    def test_falls_back_to_job_id_when_contest_missing(self):
+        fetcher = _make_fetcher()
+        self._setup_list(fetcher, [JOB_ID_ONLY_RESPONSE])
+        jobs = fetcher.list_jobs()
+        assert len(jobs) == 1
+        assert jobs[0].id == "99999"
+
+
+# ---------------------------------------------------------------------------
+# Faucet config — taleo_filters
+# ---------------------------------------------------------------------------
+
+
+class TestTaleoFilters:
+    def _setup(self, fetcher: TaleoFetcher) -> None:
+        get_resp = MagicMock()
+        get_resp.text = FTL_HTML_LOCALLOGOUT
+        get_resp.raise_for_status = MagicMock()
+        fetcher.client.get.return_value = get_resp
+
+        post_resp = MagicMock()
+        post_resp.json.return_value = SINGLE_PAGE_RESPONSE
+        post_resp.raise_for_status = MagicMock()
+        fetcher.client.post.return_value = post_resp
+
+    def test_no_filters_sends_empty_buckets(self):
+        """Backwards-compat: no taleo_filters → today's all-empty body."""
+        fetcher = _make_fetcher()
+        self._setup(fetcher)
+        fetcher.list_jobs()
+        body = fetcher.client.post.call_args.kwargs["json"]
+        for bucket in body["filterSelectionParam"]["searchFilterSelections"]:
+            assert bucket["selectedValues"] == []
+
+    def test_job_field_filter_populates_bucket(self):
+        fetcher = _make_fetcher(taleo_filters={"JOB_FIELD": ["8240753014"]})
+        self._setup(fetcher)
+        fetcher.list_jobs()
+        body = fetcher.client.post.call_args.kwargs["json"]
+        buckets = {
+            b["id"]: b["selectedValues"]
+            for b in body["filterSelectionParam"]["searchFilterSelections"]
+        }
+        assert buckets["JOB_FIELD"] == ["8240753014"]
+        # Other buckets stay empty.
+        assert buckets["LOCATION"] == []
+        assert buckets["ORGANIZATION"] == []
+
+    def test_multiple_filter_values(self):
+        fetcher = _make_fetcher(
+            taleo_filters={"JOB_FIELD": ["a", "b"], "LOCATION": ["c"]},
+        )
+        self._setup(fetcher)
+        fetcher.list_jobs()
+        body = fetcher.client.post.call_args.kwargs["json"]
+        buckets = {
+            b["id"]: b["selectedValues"]
+            for b in body["filterSelectionParam"]["searchFilterSelections"]
+        }
+        assert buckets["JOB_FIELD"] == ["a", "b"]
+        assert buckets["LOCATION"] == ["c"]
 
 
 # ---------------------------------------------------------------------------
@@ -405,7 +571,7 @@ class TestFetchDescription:
         resp.raise_for_status = MagicMock()
         fetcher.client.get.return_value = resp
 
-        desc = fetcher.fetch_description("2026-TECH-001")
+        desc = fetcher.fetch_description("341267")
         assert desc is not None
         assert "experienced engineer" in desc
 
@@ -416,8 +582,8 @@ class TestFetchDescription:
         resp.raise_for_status = MagicMock()
         fetcher.client.get.return_value = resp
 
-        custom_url = "https://textron.taleo.net/careersection/textron/jobdetail.ftl?job=2026-TECH-001&lang=en"
-        fetcher.fetch_description("2026-TECH-001", metadata={"url": custom_url})
+        custom_url = "https://textron.taleo.net/careersection/textron/jobdetail.ftl?job=341267&lang=en"
+        fetcher.fetch_description("341267", metadata={"url": custom_url})
         fetcher.client.get.assert_called_with(custom_url)
 
 
@@ -428,12 +594,12 @@ class TestFetchDescription:
 
 class TestURLParsing:
     def test_parse_textron_url(self):
-        url = "https://textron.taleo.net/careersection/textron/jobdetail.ftl?job=2026-TECH-001&lang=en"
+        url = "https://textron.taleo.net/careersection/textron/jobdetail.ftl?job=341267&lang=en"
         result = parse_url(url)
         assert result is not None
         assert result.ats == "taleo"
         assert result.board == "textron"
-        assert result.job_id == "2026-TECH-001"
+        assert result.job_id == "341267"
 
     def test_parse_aarcorp_url(self):
         url = "https://aarcorp.taleo.net/careersection/2/jobdetail.ftl?job=12345&lang=en"


### PR DESCRIPTION
## Why

PR #64 wired `TaleoFetcher` against an assumed Oracle Taleo Enterprise REST shape. Verification against the two known tenants (Textron Aviation at `textron.taleo.net`, AAR Corp at `aarcorp.taleo.net`) surfaced three independent listing-level bugs and no faucet wiring. None of the 31 prior tests caught these — they all mocked the assumed shape rather than the real one.

## What changed

**Listing-level correctness:**

- **Portal auto-discovery** now matches the live shape. The portal id appears in `jobsearch.ftl` as `careersection/locallogoutservlet.jss?portal=NNN&portalCode=...`; neither of the previously checked patterns (`rest/jobboard/searchjobs?...portal=NNN` and `"portal":"NNN"`) is present on live pages. New pattern is the first match attempted; the two legacy patterns stay as fallbacks.
- **`tz` request header** is now sent on the listing POST. Without it, both tenants return HTTP 500.
- **Listing parser** rewritten for the real shape: visible cells live under `column[]` (`column[0]` = title, `column[1]` = JSON-encoded list of locations, `column[2]` = posted-date string in tenant-specific format — `MM/DD/YYYY` on some, `Month DD, YYYY` on others; `dateutil.parser` handles both). External id is `contestNo` with `jobId` as fallback. Total count is `pagingData.totalCount`, not `requisitionCount`. Job-field / department is not in the listing payload, so `Job.department` is left None (back-fill via per-facet probes is a separate concern).

**Faucet wiring:**

- New `taleo_filters: dict[str, list[str]] | None` kwarg on `TaleoFetcher`. When set, populates the matching `filterSelectionParam.searchFilterSelections` bucket (e.g. `JOB_FIELD`, `LOCATION`, `ORGANIZATION`) with server-side facet value ids. Empty / absent → unfiltered listing (backwards-compatible). The factory at `fetchers/__init__.py` already plumbs every non-reserved Company field through `**kw`, so no factory change is needed.

**Tests:**

- Rewritten against the real shape — 31 → 42 tests. New coverage: locallogoutservlet portal discovery, `tz` header presence, `column[]` parsing for both date formats, JSON-list-string location decoding, `contestNo` → `jobId` fallback, `taleo_filters` populates the correct bucket, no-filters case stays all-empty (backwards-compat).

## Verification

Live counts against the two known tenants (these are class-of-behavior facts about the public Taleo ATS shape — same numbers any caller would see):

```
textron engineering: 125
sample: id=341724 title='Engineer' loc='US-Arizona-Mesa' date=2026-05-13

aar total: 190
sample: id=18376 title='Warehouse Tooling Clerk (1st Shift)' loc='United States-Oklahoma-Oklahoma City' date=2026-05-13

discovered portal (auto): 8140753014
```

Full test suite: 582 passed.

## Out of scope (tracked separately)

Detail-page description extraction is broken on both known tenants — `fetch_description` returns chrome-only text (~340-470 chars: "Description Qualifications : Primary Location : ...") because the JD body is filled by client JS after page load. Tracked in #66. **No Taleo companies are registered in the company table in this PR** because description-enrich would burn distill cost for an empty payload. Company registration is gated on #66.

## Closes

Nothing — issue #7 (and any "register Taleo companies" follow-up) stays open until #66 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)