### PR TITLE
store: remove orphan active jobs where company has no ATS fetcher

### DIFF
--- a/src/jobbuddy/migrations/021_cleanup_orphan_jobs.sql
+++ b/src/jobbuddy/migrations/021_cleanup_orphan_jobs.sql
@@ -1,0 +1,12 @@
+-- Mark active jobs as removed when their parent company has no ATS fetcher
+-- and the job was never enriched (description IS NULL). These jobs cannot
+-- be re-fetched or distilled and pollute full-text search with title-only
+-- records. Shape B companies (ats IS NULL, zero jobs) are unaffected.
+UPDATE jobs
+SET listing_status = 'removed',
+    removed_at = NOW()
+WHERE listing_status = 'active'
+  AND description IS NULL
+  AND company_slug IN (
+      SELECT slug FROM companies WHERE ats IS NULL
+  );


### PR DESCRIPTION
## Summary

- Adds migration `021_cleanup_orphan_jobs.sql` that marks active jobs as `removed` when their parent company has `ats IS NULL` and the job was never enriched (`description IS NULL`)
- Jobs in this shape are permanently dead corpus entries: no fetcher will re-scrape them, no enrichment will fill the description, and the distill phase skips them
- These jobs still surface in FTS results (the title field is indexed) but return no useful content — no `short_jd`, no `description_normalized`, no description — degrading search quality
- Shape B companies (`ats IS NULL` with zero jobs, i.e. bio-only research entries) are unaffected

No schema changes. `removed_at` and the `listing_status` enum value `'removed'` already exist.

## Test plan

- [x] `uv run python -m pytest tests/ -v -k "not integration"` — 616 passed, 0 failures (migrations are applied via `ensure_pg_schema` fixture in `conftest.py`, so the new file is exercised)
- [ ] After merge, run `jsb migrate` against prod to apply the cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)