### PR TITLE
store: fix stale ATS configs for Mistral (→Lever) and Thumbtack (→Ashby)

### DIFF
--- a/src/jobbuddy/migrations/022_ats_slug_fixes.sql
+++ b/src/jobbuddy/migrations/022_ats_slug_fixes.sql
@@ -1,0 +1,9 @@
+-- Mistral AI moved from Ashby to Lever.
+-- Old: api.ashbyhq.com/posting-api/job-board/mistral (404)
+-- New: jobs.lever.co/mistral (verified active)
+UPDATE companies SET ats = 'lever', board = 'mistral' WHERE slug = 'mistral';
+
+-- Thumbtack moved from Greenhouse to Ashby.
+-- Old: boards-api.greenhouse.io/v1/boards/thumbtack/jobs (404)
+-- New: jobs.ashbyhq.com/thumbtack (verified active, 7 live jobs confirmed)
+UPDATE companies SET ats = 'ashby', board = 'thumbtack' WHERE slug = 'thumbtack';


### PR DESCRIPTION
## What broke and what was verified

The dream routine's daily health check found 7 companies with 404-ing ATS boards and stale active jobs. Two were identified as verified ATS platform migrations:

- **Mistral AI** moved from Ashby to Lever. `api.ashbyhq.com/posting-api/job-board/mistral` returns 404; `jobs.lever.co/mistral` is verified active.
- **Thumbtack** moved from Greenhouse to Ashby. `boards-api.greenhouse.io/v1/boards/thumbtack/jobs` returns 404; `jobs.ashbyhq.com/thumbtack` is verified active with 7 live jobs confirmed.

Migration `022_ats_slug_fixes.sql` updates the `ats` and `board` columns for both slugs. On the next sync, the fetch phase will pick up the corrected configs and pull fresh jobs from the new endpoints. Old job IDs won't match and will be marked `removed` by the sync's stale-job detection logic automatically.

## Unresolved 404s (5 remaining)

These companies also have 404-ing ATS boards but no verified new slug yet — they need separate investigation before a fix can be applied:

- **Coinbase** — ATS board 404, new location unconfirmed
- **Runway** — ATS board 404, new location unconfirmed
- **Wordware** — ATS board 404, new location unconfirmed
- **Synchron** — ATS board 404, new location unconfirmed
- **Continua AI** — ATS board 404, new location unconfirmed

## Ordering note

Migration 021 is claimed by open PR #69. This migration is numbered 022. Either:
- Merge PR #69 first, then merge this, **or**
- Renumber this to 021 if #69 is abandoned

## Test plan

- [x] `uv run python -m pytest tests/ -v` — 619 passed, 0 failures
- [ ] After merging, run `jsb migrate` on the production DB to apply the fix
- [ ] Run `jsb sync fetch --company mistral --company thumbtack` to confirm fresh jobs are fetched from the new endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)