### PR TITLE
store: remove provably dead company configs (testcorp, retool)

### DIFF
--- a/src/jobbuddy/migrations/022_remove_dead_company_configs.sql
+++ b/src/jobbuddy/migrations/022_remove_dead_company_configs.sql
@@ -1,0 +1,17 @@
+-- Remove company configs that are provably dead and have no corpus jobs.
+--
+-- testcorp: a test entry (slug "testcorp", name "Test Corp") that has never
+--   accumulated real jobs and has been 404-ing on every sync. No FK references
+--   in jobs (confirmed 2026-05-22).
+--
+-- retool: Retool Inc. was acquired by Brex and its product shut down. The
+--   company row has ats=NULL/board=NULL with a stale Greenhouse URL in
+--   sync_status from April 2026. No FK references in jobs.
+--
+-- FK chain: jobs.company_slug → sync_status.company_slug (migration 003).
+-- sync_status has no FK to companies. Delete order: sync_status first (belt
+-- and suspenders), then companies. Both are safe because 0 jobs reference
+-- these slugs (verified 2026-05-22).
+
+DELETE FROM sync_status WHERE company_slug IN ('testcorp', 'retool');
+DELETE FROM companies WHERE slug IN ('testcorp', 'retool');


### PR DESCRIPTION
## What

Migration 022 deletes two company rows that are confirmed dead with no corpus jobs:

- **testcorp** — a test entry (slug `testcorp`, name "Test Corp") that 404s on every sync and has never accumulated real jobs
- **retool** — Retool Inc. was acquired by Brex and its product shut down; unreachable since at least April 2026, `ats=NULL`

## Safety

Both slugs have **0 rows** in the `jobs` table (verified against prod 2026-05-22). The FK chain is `jobs.company_slug → sync_status.company_slug` (migration 003) — no jobs reference these slugs, so the deletes are safe. `sync_status` has no FK to `companies`.

Merge removes these from the sync error noise on every run.

## Does NOT include

Companies with 0 jobs but no confirmed shutdown (groq, wandb, monday, etc.) — those need the explicit disable flag from issue #42 rather than deletion, in case they're worth re-configuring later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)