### PR TITLE
store: remove 6 dead company configs (acquired/ATS-moved)

### DIFF
--- a/src/jobbuddy/migrations/021_remove_dead_company_configs_batch2.sql
+++ b/src/jobbuddy/migrations/021_remove_dead_company_configs_batch2.sql
@@ -1,0 +1,30 @@
+-- Remove company configs that are provably dead and have no corpus jobs.
+--
+-- All six slugs below:
+--   - return persistent 403 or 404 on every sync attempt
+--   - have 0 rows in the jobs table (confirmed 2026-05-23)
+--   - are unreachable because the company was acquired, the product was shut
+--     down, or the ATS board moved to an unsupported platform
+--
+-- FK chain: jobs.company_slug → sync_status.company_slug (migration 003).
+-- sync_status has no FK to companies. Delete order: sync_status first (belt
+-- and suspenders), then companies. Both are safe because 0 jobs reference
+-- these slugs (verified 2026-05-23).
+
+DELETE FROM sync_status WHERE company_slug IN (
+    'adept-ai',
+    'fly',
+    'groq',
+    'replicate',
+    'wandb',
+    'wellsaid-labs'
+);
+
+DELETE FROM companies WHERE slug IN (
+    'adept-ai',
+    'fly',
+    'groq',
+    'replicate',
+    'wandb',
+    'wellsaid-labs'
+);


### PR DESCRIPTION
## What

Migration 021 deletes 6 company rows whose ATS boards return persistent 403 or 404 and have 0 total jobs in the corpus (verified 2026-05-23).

Slugs removed: `adept-ai`, `fly`, `groq`, `replicate`, `wandb`, `wellsaid-labs`.

Confirmed causes: company acquired and shut down, product acquired, or ATS board moved to an unsupported platform.

## Safety

All 6 slugs have **0 rows** in the `jobs` table — no FK references. The FK chain is `jobs.company_slug → sync_status.company_slug` (migration 003); `sync_status` has no FK to `companies`. Delete order: `sync_status` first (belt-and-suspenders), then `companies`.

## Effect

Reduces sync error noise — these slugs generate a 403/404 on every fetch run. After this migration they are gone from the sync loop entirely.

## Relationship to PR #71

PR #71 uses migration number 022. This PR uses 021. The migration system applies by sorted filename and tracks by name — the two are independent and order-safe regardless of which merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)