### PR TITLE
types: document JobRow.updated semantics in Pydantic schema

### DIFF
--- a/src/jobbuddy/core/types.py
+++ b/src/jobbuddy/core/types.py
@@ -5,7 +5,7 @@ class docstrings — keep those accurate; the MCP wrapper does not re-document
 them.
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class JobRow(BaseModel):
@@ -13,17 +13,26 @@ class JobRow(BaseModel):
 
     `posted` is an ISO date string when known; `snippet` is a ts_headline
     excerpt (when query is set) or a passive prefix of `short_jd` (when not).
+    `updated` is an ATS-side freshness signal; when both are present, prefer
+    `updated` over `posted` to judge whether a listing is current.
     """
 
     job_id: str
     title: str
     location: str | None = None
     posted: str | None = None
-    # ATS-side freshness signal (greenhouse/amazon/eightfold_v2/jibe/avature
-    # populate this; others leave it None). When the LLM sees `updated` and
-    # `posted` diverge sharply, that's the cue that an old `posted` date
-    # belongs to an actively-republished listing rather than a stale req.
-    updated: str | None = None
+    updated: str | None = Field(
+        default=None,
+        description=(
+            "ATS-side last-touch date (ISO date string). Populated by "
+            "Greenhouse, Amazon, Eightfold v2, Jibe, and Avature; None for "
+            "other platforms. When `updated` and `posted` both appear and "
+            "diverge, `posted` is the original publish date and `updated` is "
+            "the most recent ATS-side edit — the listing is old but actively "
+            "republished. Use `updated` (not `posted`) to judge freshness "
+            "when both are present."
+        ),
+    )
     snippet: str | None = None
     url: str | None = None
     salary: str | None = None


### PR DESCRIPTION
## Problem

FastMCP serializes the Pydantic model schema and passes it to the calling LLM as tool output context. Python comments are stripped during serialization — the LLM sees `updated: str | None` with no description of what the field means, which ATSes populate it, or how to interpret it relative to `posted`.

This caused operator friction when the LLM encountered results where `posted` appeared old but the listing was current. Without schema-level guidance, the LLM had no basis for recognizing that `updated` (when present) supersedes `posted` for freshness judgement — and that divergence between the two indicates an actively-republished listing rather than a stale req.

## Fix

- Add `Field(description=...)` to `updated` in `JobRow` with full semantics:
  - Which ATSes populate it (Greenhouse, Amazon, Eightfold v2, Jibe, Avature)
  - What divergence from `posted` means: the listing is old but has been republished/touched on the ATS side
  - Explicit freshness guidance: use `updated` (not `posted`) to judge currency when both are present
- Update the class docstring to surface the `updated`/`posted` relationship at a glance
- Remove the now-redundant Python comment (the `Field` description is the canonical explanation)

## Test plan

- [ ] Confirm `JobRow.model_json_schema()` includes `description` on the `updated` field
- [ ] Confirm no import errors (`Field` added to pydantic import)
- [ ] Confirm existing tests pass (`uv run python -m pytest tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)