### PR TITLE
mcp: add GitHub-OAuth-over-HTTP run mode for self-hosted deployment

### DIFF
--- a/src/jobbuddy/mcp_server.py
+++ b/src/jobbuddy/mcp_server.py
@@ -1,4 +1,8 @@
-"""MCP server entry point: wires Azure auth, telemetry, and starts FastMCP.
+"""MCP server entry point: wires auth, telemetry, and starts FastMCP.
+
+`main()` selects a run mode: Azure Functions (Entra OAuth + Redis, gated on
+`ENTRA_OAUTH_CLIENT_ID`), devbox HTTP (GitHub OAuth, no Redis, gated on
+`GITHUB_OAUTH_CLIENT_ID`), or bare stdio (no auth).
 
 Tool and resource implementations live in `jobbuddy.mcp_tools.*`. Importing
 that package registers everything on the shared `mcp` instance defined in
@@ -73,6 +77,29 @@ def build_azure_auth():
     return auth
 
 
+def build_github_auth():
+    """Build GitHubProvider for the devbox HTTP deployment.
+
+    Unlike the Azure path, one long-lived devbox process backs OAuth/DCR
+    state in memory — no Redis, no Entra. Reads GITHUB_OAUTH_* and BASE_URL
+    from the environment.
+    """
+    from fastmcp.server.auth.providers.github import GitHubProvider
+
+    client_id = os.environ["GITHUB_OAUTH_CLIENT_ID"]
+    client_secret = os.environ["GITHUB_OAUTH_CLIENT_SECRET"]
+    base_url = os.environ.get("BASE_URL", "http://localhost:8001")
+
+    auth = GitHubProvider(
+        client_id=client_id,
+        client_secret=client_secret,
+        base_url=base_url,
+    )
+
+    log.info("GitHubProvider initialized (base_url=%s)", base_url)
+    return auth
+
+
 async def assert_account_dependency_stripped() -> None:
     """Confirm FastMCP's DI machinery hides the `account` parameter from
     every tool's JSON schema. If a fastmcp regression or downgrade ever
@@ -132,6 +159,27 @@ def main():
         asyncio.run(assert_account_dependency_stripped())
 
         auth = build_azure_auth()
+        mcp.auth = auth
+        mcp.run(transport="streamable-http", stateless_http=True)
+    elif os.environ.get("GITHUB_OAUTH_CLIENT_ID"):
+        # Devbox HTTP deployment: GitHub OAuth, local Postgres, no Redis/Entra.
+        # Host/port come from FASTMCP_HOST/FASTMCP_PORT (set in the systemd unit
+        # so jsb binds localhost:8001 and stays off SMH's :8000).
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        )
+
+        if get_settings().auth_provider != "github":
+            raise RuntimeError(
+                "GITHUB_OAUTH_CLIENT_ID is set but JOBBUDDY_AUTH_PROVIDER is not "
+                "\"github\". Authenticated tools cannot resolve a claim shape "
+                "without it."
+            )
+
+        asyncio.run(assert_account_dependency_stripped())
+
+        auth = build_github_auth()
         mcp.auth = auth
         mcp.run(transport="streamable-http", stateless_http=True)
     else:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,30 @@
+"""Tests for the MCP server run-mode auth builders.
+
+`build_azure_auth()` is not unit-tested — it needs a live Redis. `build_github_auth()`
+is pure config (no network in GitHubProvider.__init__), so it's cheap to cover.
+`main()` itself is the server runner and is validated live, not here.
+"""
+
+import pytest
+
+from jobbuddy.mcp_server import build_github_auth
+
+
+def test_build_github_auth_reads_env(monkeypatch):
+    from fastmcp.server.auth.providers.github import GitHubProvider
+
+    monkeypatch.setenv("GITHUB_OAUTH_CLIENT_ID", "Iv1.testclientid")
+    monkeypatch.setenv("GITHUB_OAUTH_CLIENT_SECRET", "testsecret")
+    monkeypatch.setenv("BASE_URL", "https://devbox.example.ts.net:8443")
+
+    auth = build_github_auth()
+
+    assert isinstance(auth, GitHubProvider)
+
+
+def test_build_github_auth_requires_client_id(monkeypatch):
+    monkeypatch.delenv("GITHUB_OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.setenv("GITHUB_OAUTH_CLIENT_SECRET", "testsecret")
+
+    with pytest.raises(KeyError):
+        build_github_auth()


### PR DESCRIPTION
## What

Adds a third run mode to `mcp_server.py::main()`: GitHub OAuth over HTTP, gated on `GITHUB_OAUTH_CLIENT_ID`. This lets the MCP server run on a plain self-hosted host with local Postgres — no Azure Managed Redis, no Entra — alongside the existing Azure-Functions mode (gated on `ENTRA_OAUTH_CLIENT_ID`) and bare stdio.

## Why

The Azure-Functions deployment (Entra OAuth + Redis-backed OAuth state) is heavier than a single-host self-hosted deployment needs. A long-lived process can keep OAuth/DCR state in memory, so the GitHub path drops Redis entirely.

## How

- `build_github_auth()` mirrors `build_azure_auth()` but constructs a FastMCP `GitHubProvider` (in-memory client storage). Reads `GITHUB_OAUTH_*` and `BASE_URL` from the environment.
- The new `elif` branch reuses the same `auth_provider` validation and the `assert_account_dependency_stripped()` startup guard as the Azure path. **The Azure path is untouched.**
- GitHub auth was already plumbed end to end (`settings.auth_provider` Literal, `pick_external_id` / `upsert_account_from_claims` keyed on the github `sub` claim) — this only adds the HTTP run-mode wiring.
- Host/port bind via `FASTMCP_HOST` / `FASTMCP_PORT` (deployment config), kept out of code.

## Test

- New `tests/test_mcp_server.py`: `build_github_auth()` constructs a `GitHubProvider` from env, and raises `KeyError` when the client id is missing.
- Full suite still collects (622 tests); `main()` itself (server runner) is validated live against the running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)