### PR TITLE
fix: tolerate explicit null location from ATS instead of failing the whole sync

### DIFF
--- a/src/jobbuddy/models.py
+++ b/src/jobbuddy/models.py
@@ -77,6 +77,16 @@ class Job(BaseModel):
     description: str | None = None
     ats_metadata: dict | None = Field(default=None, exclude=True)
 
+    @field_validator("location", mode="before")
+    @classmethod
+    def coerce_null_location(cls, v: str | None) -> str:
+        # ATSes occasionally emit an explicit "location": null. Fetchers guard
+        # the *missing* key with .get("location", "") but that returns None on
+        # an explicit null, which would reject here and fail the whole
+        # company's sync over one bad job. "" is the no-location representation
+        # everywhere downstream, so coerce rather than raise.
+        return v or ""
+
 
 class Company(BaseModel):
     """A company in the registry. Slug is normalized at construction time."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,23 @@
 
 from datetime import date, datetime, timezone
 
-from jobbuddy.models import parse_published_at
+from jobbuddy.models import Job, parse_published_at
+
+
+class TestJobLocation:
+    """An ATS that emits an explicit ``"location": null`` must not take down
+    the whole company's sync. ``dict.get("location", "")`` defends a *missing*
+    key but returns None on an explicit null, so the value reaches Job; the
+    model is the single chokepoint that has to tolerate it. Coerce None to ""
+    — the already-handled no-location representation — rather than raising."""
+
+    BASE = dict(id="1", title="Engineer", url="u", apply_url="a")
+
+    def test_explicit_none_location_coerced_to_empty(self):
+        assert Job(location=None, **self.BASE).location == ""
+
+    def test_real_location_preserved(self):
+        assert Job(location="Remote, US", **self.BASE).location == "Remote, US"
 
 
 class TestParsePublishedAt:


### PR DESCRIPTION
## What

A `field_validator` on `Job.location` coerces an explicit `None` to `""` (the no-location representation already used everywhere downstream), instead of letting it raise a Pydantic `ValidationError`.

## Why

A company erroring on the last sync did so with exactly this:

```
1 validation error for Job
location
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

Its ATS emitted a posting with `"location": null`. Fetchers guard a *missing* key with `.get("location", "")`, but `dict.get` returns `None` on an **explicit** null — so `None` reaches `location: str` and raises. That error propagates out of `list_jobs()` and **fails the entire company's sync**: every active job for that company is dropped over one malformed posting, and the prior listings go stale silently.

This is a class-of-behavior bug, not a one-company quirk: the same `.get("location", "")` null-vs-missing trap is in `greenhouse`, `workday`, `oracle_hcm`, `phenom`, and `jobsync`. Fixing it at the model chokepoint defends all 15 ATS platforms with one change. `successfactors` already hand-rolls the same `location or ""` defense locally — this generalizes it.

## Scope

- Coerces `None` → `""`. Behaviorally identical to the existing missing-key path; downstream code already treats `""` as "no location".
- Field stays **required** — every fetcher passes `location=`, so a truly missing kwarg is not an observed case and is left to fail loudly.
- TDD: the failing test reproduces the live crash before the fix. Full suite (624 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)