### PR TITLE
ashby: fall back to hosted-board GraphQL when the posting API is disabled

### DIFF
--- a/src/jobbuddy/fetchers/ashby.py
+++ b/src/jobbuddy/fetchers/ashby.py
@@ -1,6 +1,7 @@
 """Ashby ATS fetcher."""
 
 import re
+import time
 from typing import Any
 
 import httpx
@@ -11,8 +12,30 @@ from jobbuddy.fetchers.base import (
     ProgressCallback,
     RetryCallback,
 )
-from jobbuddy.models import Job
+from jobbuddy.models import Job, strip_html
 
+
+_GRAPHQL_URL = "https://jobs.ashbyhq.com/api/non-user-graphql"
+
+_JOB_BOARD_QUERY = (
+    "query ApiJobBoardWithTeams($organizationHostedJobsPageName: String!) { "
+    "jobBoard: jobBoardWithTeams("
+    "organizationHostedJobsPageName: $organizationHostedJobsPageName) { "
+    "teams { id name } "
+    "jobPostings { id title teamId locationName employmentType "
+    "compensationTierSummary } "
+    "} }"
+)
+
+_JOB_POSTING_QUERY = (
+    "query ApiJobPosting($organizationHostedJobsPageName: String!, "
+    "$jobPostingId: String!) { "
+    "jobPosting(organizationHostedJobsPageName: $organizationHostedJobsPageName, "
+    "jobPostingId: $jobPostingId) { "
+    "id title departmentName locationName descriptionHtml "
+    "compensationTierSummary publishedDate "
+    "} }"
+)
 
 _APPLICATION_FORM_QUERY = (
     "query ApiJobPosting($organizationHostedJobsPageName: String!, "
@@ -26,6 +49,11 @@ _APPLICATION_FORM_QUERY = (
 
 class AshbyFetcher(ATSFetcher):
     ats_type = "ashby"
+
+    # Pacing between GraphQL detail calls on the posting-API-disabled
+    # fallback path; the non-user-graphql endpoint 429s under bursts
+    # (observed live: 4 req/s trips it even with backoff retries).
+    graphql_detail_delay: float = 1.0
 
     def resolve_name(self) -> str | None:
         """Fetch company display name from Ashby page title ("<Company> Jobs")."""
@@ -45,6 +73,13 @@ class AshbyFetcher(ATSFetcher):
     def list_jobs(self, *, on_progress: ProgressCallback | None = None, on_retry: RetryCallback | None = None) -> list[Job]:
         url = f"https://api.ashbyhq.com/posting-api/job-board/{self.board}?includeCompensation=true"
         resp = self.client.get(url)
+        if resp.status_code == 404:
+            # Some boards disable the public posting API while the hosted
+            # board at jobs.ashbyhq.com/<board> stays live (e.g. Whatnot,
+            # EvenUp). The hosted board's GraphQL endpoint still serves
+            # the postings, so a posting-API 404 means "fetch via
+            # GraphQL", not "company left Ashby".
+            return self._list_jobs_graphql(on_progress=on_progress, on_retry=on_retry)
         resp.raise_for_status()
         data = resp.json()
         jobs = []
@@ -68,6 +103,85 @@ class AshbyFetcher(ATSFetcher):
                     description=j.get("descriptionPlain"),
                 )
             )
+        return jobs
+
+    def _graphql(
+        self,
+        op: str,
+        query: str,
+        variables: dict,
+        *,
+        on_retry: RetryCallback | None = None,
+    ) -> dict:
+        def _post() -> dict:
+            resp = self.client.post(
+                f"{_GRAPHQL_URL}?op={op}",
+                json={"operationName": op, "variables": variables, "query": query},
+            )
+            resp.raise_for_status()
+            return resp.json().get("data") or {}
+
+        return self._retry_request(_post, on_retry=on_retry)
+
+    def _list_jobs_graphql(
+        self,
+        *,
+        on_progress: ProgressCallback | None = None,
+        on_retry: RetryCallback | None = None,
+    ) -> list[Job]:
+        """List jobs via the hosted job board's GraphQL endpoint.
+
+        The board listing carries only id/title/team/location, so each
+        posting needs one detail call for description, published date,
+        department, and compensation summary. Detail calls are paced —
+        the endpoint 429s under rapid-fire requests.
+        """
+        data = self._graphql(
+            "ApiJobBoardWithTeams",
+            _JOB_BOARD_QUERY,
+            {"organizationHostedJobsPageName": self.board},
+            on_retry=on_retry,
+        )
+        board = data.get("jobBoard")
+        if board is None:
+            raise ValueError(
+                f"Ashby board {self.board} not found via posting API or hosted job board"
+            )
+        teams = {t["id"]: t["name"] for t in board.get("teams") or []}
+        postings = board.get("jobPostings") or []
+        jobs = []
+        for p in postings:
+            if jobs and self.graphql_detail_delay:
+                time.sleep(self.graphql_detail_delay)
+            detail = self._graphql(
+                "ApiJobPosting",
+                _JOB_POSTING_QUERY,
+                {
+                    "organizationHostedJobsPageName": self.board,
+                    "jobPostingId": p["id"],
+                },
+                on_retry=on_retry,
+            ).get("jobPosting") or {}
+            description_html = detail.get("descriptionHtml")
+            published = detail.get("publishedDate") or ""
+            url = f"https://jobs.ashbyhq.com/{self.board}/{p['id']}"
+            jobs.append(
+                Job(
+                    id=p["id"],
+                    title=p["title"],
+                    location=p.get("locationName") or "",
+                    url=url,
+                    apply_url=f"{url}/application",
+                    published_at=published[:10] if published else None,
+                    department=detail.get("departmentName"),
+                    team=teams.get(p.get("teamId")),
+                    salary=detail.get("compensationTierSummary")
+                    or p.get("compensationTierSummary"),
+                    description=strip_html(description_html) if description_html else None,
+                )
+            )
+            if on_progress:
+                on_progress(len(jobs), len(postings))
         return jobs
 
     def fetch_job(self, job_id: str) -> Job:

--- a/tests/test_ashby.py
+++ b/tests/test_ashby.py
@@ -1,0 +1,200 @@
+"""Tests for the Ashby fetcher.
+
+Some Ashby boards disable the public posting API
+(`api.ashbyhq.com/posting-api/job-board/<board>` returns 404) while the
+hosted job board at `jobs.ashbyhq.com/<board>` stays live, served by the
+same `non-user-graphql` endpoint the fetcher already uses for application
+forms. The fetcher falls back to that GraphQL surface when the posting
+API 404s, so a disabled posting API reads as "fetch via GraphQL", not
+"company left Ashby".
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from jobbuddy.fetchers.ashby import AshbyFetcher
+
+
+SAMPLE_POSTING_API = {
+    "jobs": [
+        {
+            "id": "aaa-111",
+            "title": "Backend Engineer",
+            "location": "Remote",
+            "jobUrl": "https://jobs.ashbyhq.com/acme/aaa-111",
+            "applyUrl": "https://jobs.ashbyhq.com/acme/aaa-111/application",
+            "publishedAt": "2026-05-01T00:00:00Z",
+            "department": "Engineering",
+            "team": "Platform",
+            "compensation": {"compensationTierSummary": "$150K – $200K"},
+            "descriptionPlain": "Build the backend.",
+        },
+    ]
+}
+
+GRAPHQL_BOARD = {
+    "data": {
+        "jobBoard": {
+            "teams": [
+                {"id": "team-1", "name": "Sales"},
+                {"id": "team-2", "name": "Engineering"},
+            ],
+            "jobPostings": [
+                {
+                    "id": "bbb-222",
+                    "title": "Account Executive",
+                    "teamId": "team-1",
+                    "locationName": "San Francisco, CA",
+                    "employmentType": "FullTime",
+                    "compensationTierSummary": None,
+                },
+                {
+                    "id": "ccc-333",
+                    "title": "Staff Engineer",
+                    "teamId": "team-2",
+                    "locationName": "Remote",
+                    "employmentType": "FullTime",
+                    "compensationTierSummary": "$180K – $240K",
+                },
+            ],
+        }
+    }
+}
+
+GRAPHQL_DETAILS = {
+    "bbb-222": {
+        "data": {
+            "jobPosting": {
+                "id": "bbb-222",
+                "title": "Account Executive",
+                "departmentName": "Sales",
+                "locationName": "San Francisco, CA",
+                "descriptionHtml": "<p>Sell the <strong>product</strong>.</p>",
+                "compensationTierSummary": None,
+                "publishedDate": "2026-04-15",
+            }
+        }
+    },
+    "ccc-333": {
+        "data": {
+            "jobPosting": {
+                "id": "ccc-333",
+                "title": "Staff Engineer",
+                "departmentName": "Engineering",
+                "locationName": "Remote",
+                "descriptionHtml": "<p>Own hard problems.</p>",
+                "compensationTierSummary": "$180K – $240K",
+                "publishedDate": "2026-05-20",
+            }
+        }
+    },
+}
+
+
+def _make_fetcher() -> AshbyFetcher:
+    f = AshbyFetcher("acme")
+    f.client = MagicMock()
+    return f
+
+
+def _mock_response(json_data, status_code: int = 200) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"{status_code}", request=MagicMock(), response=resp
+        )
+    else:
+        resp.raise_for_status = MagicMock()
+    return resp
+
+
+def test_posting_api_happy_path():
+    """Posting API available: jobs come from it, no GraphQL calls made."""
+    f = _make_fetcher()
+    f.client.get.return_value = _mock_response(SAMPLE_POSTING_API)
+
+    jobs = f.list_jobs()
+
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.id == "aaa-111"
+    assert j.salary == "$150K – $200K"
+    assert j.description == "Build the backend."
+    f.client.post.assert_not_called()
+
+
+def test_posting_api_404_falls_back_to_graphql():
+    """Posting API 404 → list via GraphQL board + per-job detail calls."""
+    f = _make_fetcher()
+    f.client.get.return_value = _mock_response({}, status_code=404)
+
+    def graphql_post(url, json=None, **kwargs):
+        op = json["operationName"]
+        if op == "ApiJobBoardWithTeams":
+            return _mock_response(GRAPHQL_BOARD)
+        if op == "ApiJobPosting":
+            return _mock_response(GRAPHQL_DETAILS[json["variables"]["jobPostingId"]])
+        raise AssertionError(f"unexpected GraphQL op {op}")
+
+    f.client.post.side_effect = graphql_post
+
+    jobs = f.list_jobs()
+
+    assert [j.id for j in jobs] == ["bbb-222", "ccc-333"]
+
+    ae = jobs[0]
+    assert ae.title == "Account Executive"
+    assert ae.location == "San Francisco, CA"
+    assert ae.url == "https://jobs.ashbyhq.com/acme/bbb-222"
+    assert ae.apply_url == "https://jobs.ashbyhq.com/acme/bbb-222/application"
+    assert ae.department == "Sales"
+    assert ae.team == "Sales"  # resolved from board teams via teamId
+    assert ae.salary is None
+    assert ae.description == "Sell the product."  # HTML stripped
+    assert str(ae.published_at) == "2026-04-15"
+
+    se = jobs[1]
+    assert se.salary == "$180K – $240K"
+    assert se.team == "Engineering"
+    assert se.description == "Own hard problems."
+
+
+def test_posting_api_non_404_error_raises():
+    """A 500 from the posting API is a real error, not a fallback trigger."""
+    f = _make_fetcher()
+    f.client.get.return_value = _mock_response({}, status_code=500)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        f.list_jobs()
+    f.client.post.assert_not_called()
+
+
+def test_graphql_fallback_board_gone_raises():
+    """404 on posting API AND null jobBoard from GraphQL = board truly gone."""
+    f = _make_fetcher()
+    f.client.get.return_value = _mock_response({}, status_code=404)
+    f.client.post.return_value = _mock_response({"data": {"jobBoard": None}})
+
+    with pytest.raises(ValueError, match="acme"):
+        f.list_jobs()
+
+
+def test_fetch_job_uses_fallback_listing():
+    """fetch_job filters list_jobs, so the fallback path serves it too."""
+    f = _make_fetcher()
+    f.client.get.return_value = _mock_response({}, status_code=404)
+
+    def graphql_post(url, json=None, **kwargs):
+        op = json["operationName"]
+        if op == "ApiJobBoardWithTeams":
+            return _mock_response(GRAPHQL_BOARD)
+        return _mock_response(GRAPHQL_DETAILS[json["variables"]["jobPostingId"]])
+
+    f.client.post.side_effect = graphql_post
+
+    job = f.fetch_job("ccc-333")
+    assert job.title == "Staff Engineer"


### PR DESCRIPTION
## What

Some Ashby boards disable the public posting API (`api.ashbyhq.com/posting-api/job-board/<board>` → 404) while the hosted board at `jobs.ashbyhq.com/<board>` stays live. The fetcher treated that 404 as a dead board, so those companies read as "left Ashby" and their corpus jobs went permanently stale.

`list_jobs` now falls back to the hosted board's `non-user-graphql` endpoint — the same surface the fetcher already uses for application forms: `ApiJobBoardWithTeams` for the listing, plus one `ApiJobPosting` detail call per posting (description, published date, department, compensation summary). A null `jobBoard` from GraphQL still raises, so genuinely-gone boards keep surfacing as sync errors.

## Why it matters

Two companies currently in the Ashby-404 error set are this exact case, verified live against both endpoints:

- **whatnot** — 211 active jobs stale in the corpus; hosted board serves 124 live postings
- **evenup** — classified as a dead config (0 jobs); hosted board serves 73 live postings

Both recover on the next sync after merge, with zero config changes. The other 11 Ashby-404 companies return a null `jobBoard` from GraphQL too — they genuinely left Ashby and keep erroring as before.

## Rate limiting

The GraphQL endpoint 429s under bursts (observed live: ~4 req/s trips it even with backoff retries). Detail calls are paced at 1/s (`graphql_detail_delay`, editable) and wrapped in the base `_retry_request` helper, which honors `Retry-After`.

## Verification

- TDD: 5 new tests in `tests/test_ashby.py` (happy path unchanged, 404→fallback field mapping, non-404 errors still raise, null-board raises, `fetch_job` via fallback). Full suite: 626 passed, 1 pre-existing failure (`test_update_company_bio_writes_all_fields` — cross-host clock skew between the test machine and the Postgres server; fails identically on clean `main`).
- Live end-to-end fetch of the real whatnot board through the fallback path: **124/124 jobs with descriptions, 124/124 with published dates, 109/124 with salary**, at 1/s pacing with no 429s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)